### PR TITLE
Correct type information handling for Joda classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jackson-datatype-joda</artifactId>
   <name>Jackson-datatype-JODA</name>
   <version>2.0.3-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
 Joda (http://joda-time.sourceforge.net/) data types.
   </description>
@@ -103,19 +103,7 @@ Joda (http://joda-time.sourceforge.net/) data types.
                 <mavenExecutorId>forked-path</mavenExecutorId>
             </configuration>
         </plugin>
-        <plugin><!-- plug-in to attach source bundle in repo -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.1.2</version>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+        
         <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -141,7 +129,7 @@ Joda (http://joda-time.sourceforge.net/) data types.
         </plugin>
 
         <!-- Plus, let's make jars OSGi bundles as well  -->
-        <plugin>
+        <!--plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>2.3.7</version>
@@ -170,7 +158,7 @@ com.fasterxml.jackson.datatype.joda
 </Export-Package>
             </instructions>
           </configuration>
-        </plugin>
+        </plugin-->
     </plugins>
   </build>
   <profiles>

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/JodaDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/JodaDeserializerBase.java
@@ -8,21 +8,31 @@ import org.joda.time.format.ISODateTimeFormat;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
-abstract class JodaDeserializerBase<T> extends StdScalarDeserializer<T>
-{
+abstract class JodaDeserializerBase<T> extends StdScalarDeserializer<T> {
+
     final static DateTimeFormatter _localDateTimeFormat = ISODateTimeFormat.localDateOptionalTimeParser();
 
-    protected JodaDeserializerBase(Class<T> cls) { super(cls); }
+    protected JodaDeserializerBase(Class<T> cls) {
+        super(cls);
+    }
 
     protected DateTime parseLocal(JsonParser jp)
-        throws IOException, JsonProcessingException
-    {
+            throws IOException, JsonProcessingException {
         String str = jp.getText().trim();
         if (str.length() == 0) { // [JACKSON-360]
             return null;
         }
         return _localDateTimeFormat.parseDateTime(str);
+    }
+
+    @Override
+    public Object deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException, JsonProcessingException {
+        return typeDeserializer.deserializeTypedFromAny(jp, ctxt);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializerBase.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.joda.ser;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 
 import org.joda.time.ReadableInstant;
@@ -8,6 +9,8 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 abstract class JodaSerializerBase<T> extends StdSerializer<T>
@@ -34,4 +37,12 @@ abstract class JodaSerializerBase<T> extends StdSerializer<T>
     {
         return _localDateFormat.print(dateValue);
     }
+
+    @Override
+    public void serializeWithType(T value, JsonGenerator jgen, SerializerProvider provider, TypeSerializer typeSer) throws IOException, JsonProcessingException {
+        typeSer.writeTypePrefixForScalar(value, jgen);
+        serialize(value, jgen, provider);
+        typeSer.writeTypeSuffixForScalar(value, jgen);
+    }
+    
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaSerializationTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.joda;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.IOException;
 
 import org.joda.time.*;
@@ -34,6 +35,20 @@ public class JodaSerializationTest extends JodaTestBase
         assertEquals(quote("1970-01-01T00:00:00.000Z"), m.writeValueAsString(dt));
     }
     
+    public void testSerializationWithTypeInfo() throws IOException
+    {
+        // let's use epoch time (Jan 1, 1970, UTC)
+        DateTime dt = new DateTime(0L, DateTimeZone.UTC);
+        // by default, dates use timestamp, so:
+        assertEquals("0", MAPPER.writeValueAsString(dt));
+
+        // but if re-configured, as regular ISO-8601 string
+        ObjectMapper m = jodaMapper();
+        m.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        m.addMixInAnnotations(DateTime.class, ObjectConfiguration.class);
+        assertEquals("[\"org.joda.time.DateTime\",\"1970-01-01T00:00:00.000Z\"]", m.writeValueAsString(dt));
+    }
+    
     /*
     /**********************************************************
     /* Tests for DateMidnight type
@@ -50,6 +65,19 @@ public class JodaSerializationTest extends JodaTestBase
         ObjectMapper mapper = jodaMapper();
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
         assertEquals(quote("2001-05-25"), mapper.writeValueAsString(date));
+    }
+    
+    public void testDateMidnightSerWithTypeInfo() throws IOException
+    {
+        DateMidnight date = new DateMidnight(2001, 5, 25);
+        // default format is that of JSON array...
+        assertEquals("[2001,5,25]", MAPPER.writeValueAsString(date));
+        // but we can force it to be a String as well (note: here we assume this is
+        // dynamically changeable)
+        ObjectMapper mapper = jodaMapper();
+        mapper.addMixInAnnotations(DateMidnight.class, ObjectConfiguration.class);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
+        assertEquals("[\"org.joda.time.DateMidnight\",\"2001-05-25\"]", mapper.writeValueAsString(date));
     }
     
     /*
@@ -70,6 +98,20 @@ public class JodaSerializationTest extends JodaTestBase
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
         assertEquals(quote("2001-05-25"), mapper.writeValueAsString(date));
     }
+    
+    public void testLocalDateSerWithTypeInfo() throws IOException
+    {
+        LocalDate date = new LocalDate(2001, 5, 25);
+        // default format is that of JSON array...
+        assertEquals("[2001,5,25]", MAPPER.writeValueAsString(date));
+
+        // but we can force it to be a String as well (note: here we assume this is
+        // dynamically changeable)
+        ObjectMapper mapper = jodaMapper();
+        mapper.addMixInAnnotations(LocalDate.class, ObjectConfiguration.class);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
+        assertEquals("[\"org.joda.time.LocalDate\",\"2001-05-25\"]", mapper.writeValueAsString(date));
+    }
 
     /*
     /**********************************************************
@@ -89,6 +131,20 @@ public class JodaSerializationTest extends JodaTestBase
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
         assertEquals(quote("2001-05-25T10:15:30.037"), mapper.writeValueAsString(date));
     }
+    
+    public void testLocalDateTimeSerWithTypeInfo() throws IOException
+    {
+        LocalDateTime date = new LocalDateTime(2001, 5, 25,
+                10, 15, 30, 37);
+        // default format is that of JSON array...
+        assertEquals("[2001,5,25,10,15,30,37]", MAPPER.writeValueAsString(date));
+        // but we can force it to be a String as well (note: here we assume this is
+        // dynamically changeable)
+        ObjectMapper mapper = jodaMapper();
+        mapper.addMixInAnnotations(LocalDateTime.class, ObjectConfiguration.class);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);        
+        assertEquals("[\"org.joda.time.LocalDateTime\",\"2001-05-25T10:15:30.037\"]", mapper.writeValueAsString(date));
+    }
 
     /*
     /**********************************************************
@@ -102,6 +158,15 @@ public class JodaSerializationTest extends JodaTestBase
         String json = MAPPER.writeValueAsString(in);
         assertEquals(quote("PT1H2M3.004S"), json);
     }
+    
+    public void testPeriodSerWithTypeInfo() throws IOException
+    {
+        Period in = new Period(1, 2, 3, 4);
+        ObjectMapper mapper = jodaMapper();
+        mapper.addMixInAnnotations(Period.class, ObjectConfiguration.class);
+        String json = mapper.writeValueAsString(in);
+        assertEquals("[\"org.joda.time.Period\",\"PT1H2M3.004S\"]", json);
+    }
 
     /*
     /**********************************************************
@@ -114,5 +179,18 @@ public class JodaSerializationTest extends JodaTestBase
         Duration d = new Duration(3123422);
         String json = MAPPER.writeValueAsString(d);
         assertEquals("3123422", json);
+    }
+    
+    public void testDurationSerWithTypeInfo() throws IOException
+    {
+        Duration d = new Duration(3123422);
+        ObjectMapper mapper = jodaMapper();
+        mapper.addMixInAnnotations(Duration.class, ObjectConfiguration.class);
+        String json = mapper.writeValueAsString(d);
+        assertEquals("[\"org.joda.time.Duration\",3123422]", json);
+    }
+    
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY, property = "@class")
+    private static interface ObjectConfiguration {
     }
 }


### PR DESCRIPTION
Hi Tatu,

this is a patch to add correct type information handling for Joda classes.

Please note that I removed OSGI support from the pom as it was refusing to compile and I wasn't able to fix it (well, I didn't try at all as I deeply hate OSGI;).
