### PR TITLE
updated joda-time to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,12 @@ Joda (http://joda-time.sourceforge.net/) data types.
     <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>1.6</version>
+        <version>2.1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.joda</groupId>
+        <artifactId>joda-convert</artifactId>
+        <version>1.2</version>
     </dependency>
 
     <!--  Test Dependencies -->


### PR DESCRIPTION
I have updated joda-time to 2.1. This is the first step to supporting joda-time 2.x data types. All tests pass.
