### PR TITLE
Issue #8: Changed DateTimeDeserializer to account for time zone

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
@@ -1,17 +1,16 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
-import java.io.IOException;
-
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.ReadableDateTime;
-import org.joda.time.ReadableInstant;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
+
+import java.io.IOException;
 
 /**
  * Basic deserializer for {@link ReadableDateTime} and its subtypes.
@@ -39,14 +38,14 @@ public class DateTimeDeserializer
     {
         JsonToken t = jp.getCurrentToken();
         if (t == JsonToken.VALUE_NUMBER_INT) {
-            return new DateTime(jp.getLongValue(), DateTimeZone.UTC);
+            return new DateTime(jp.getLongValue(), DateTimeZone.forTimeZone(ctxt.getTimeZone()));
         }
         if (t == JsonToken.VALUE_STRING) {
             String str = jp.getText().trim();
             if (str.length() == 0) { // [JACKSON-360]
                 return null;
             }
-            return new DateTime(str, DateTimeZone.UTC);
+            return new DateTime(str, DateTimeZone.forTimeZone(ctxt.getTimeZone()));
         }
         throw ctxt.mappingException(getValueClass());
     }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
@@ -1,13 +1,14 @@
 package com.fasterxml.jackson.datatype.joda;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.io.*;
-import java.util.*;
-
-
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.*;
 
-import com.fasterxml.jackson.databind.*;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 /**
  * Unit tests for verifying limited interoperability for Joda time.
@@ -49,6 +50,18 @@ public class JodaDeserializationTest extends JodaTestBase
         ReadableDateTime date = MAPPER.readValue(quote("1972-12-28T12:00:01.000+0000"), ReadableDateTime.class);
         assertNotNull(date);
         assertEquals("1972-12-28T12:00:01.000Z", date.toString());
+
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), ReadableDateTime.class));
+    }
+
+    // since 2.1.3, for github issue #8
+    public void testDeserReadableDateTimeWithTimeZoneInfo() throws IOException
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("GMT-6"));
+        ReadableDateTime date = MAPPER.readValue(quote("1972-12-28T12:00:01.000-0600"), ReadableDateTime.class);
+        assertNotNull(date);
+        assertEquals("1972-12-28T12:00:01.000-06:00", date.toString());
 
         // since 1.6.1, for [JACKSON-360]
         assertNull(MAPPER.readValue(quote(""), ReadableDateTime.class));


### PR DESCRIPTION
ObjectMapper.setTimeZone(TimeZone timeZone) is used for setting the TimeZone with which date-times are parsed. However, DateTimeDeserializer ignores this setting. I have changed this to use the configured mapper time zone now and included a unit test to demonstrate that it works.
