### PR TITLE
Add serializers and deserializers for MonthDay and YearMonth.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
@@ -27,6 +27,8 @@ public class JodaModule extends SimpleModule
         addDeserializer(ReadableDateTime.class, DateTimeDeserializer.forType(ReadableDateTime.class));
         addDeserializer(ReadableInstant.class, DateTimeDeserializer.forType(ReadableInstant.class));
         addDeserializer(Interval.class, new IntervalDeserializer());
+        addDeserializer(MonthDay.class, new MonthDayDeserializer());
+        addDeserializer(YearMonth.class, new YearMonthDeserializer());
 
         // then serializers:
         addSerializer(DateMidnight.class, new DateMidnightSerializer());
@@ -38,5 +40,7 @@ public class JodaModule extends SimpleModule
         addSerializer(LocalTime.class, new LocalTimeSerializer());
         addSerializer(Period.class, ToStringSerializer.instance);
         addSerializer(Interval.class, new IntervalSerializer());
+        addSerializer(MonthDay.class, ToStringSerializer.instance);
+        addSerializer(YearMonth.class, ToStringSerializer.instance);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserializer.java
@@ -1,0 +1,42 @@
+package com.fasterxml.jackson.datatype.joda.deser;
+
+import java.io.IOException;
+
+import org.joda.time.MonthDay;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+/**
+ * A Jackson deserializer for Joda MonthDay objects.
+ * <p>
+ * Expects a string value compatible with MonthDay's parse operation.
+ */
+public class MonthDayDeserializer extends JodaDeserializerBase<MonthDay>
+{
+
+    private static final long serialVersionUID = -2360834248497553111L;
+
+    public MonthDayDeserializer()
+    {
+        super(MonthDay.class);
+    }
+
+    @Override
+    public MonthDay deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException
+    {
+        JsonToken t = jp.getCurrentToken();
+        if (t == JsonToken.VALUE_STRING)
+        {
+            String str = jp.getText().trim();
+            if (str.isEmpty())
+            {
+                return null;
+            }
+            return MonthDay.parse(str);
+        }
+        throw ctxt.wrongTokenException(jp, JsonToken.VALUE_STRING, "expected JSON String");
+    }
+
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserializer.java
@@ -1,0 +1,42 @@
+package com.fasterxml.jackson.datatype.joda.deser;
+
+import java.io.IOException;
+
+import org.joda.time.YearMonth;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+/**
+ * A Jackson deserializer for Joda YearMonth objects.
+ * <p>
+ * Expects a string value compatible with YearMonth's parse operation.
+ */
+public class YearMonthDeserializer extends JodaDeserializerBase<YearMonth>
+{
+
+    private static final long serialVersionUID = -3830851040664795250L;
+
+    public YearMonthDeserializer()
+    {
+        super(YearMonth.class);
+    }
+
+    @Override
+    public YearMonth deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException
+    {
+        JsonToken t = jp.getCurrentToken();
+        if (t == JsonToken.VALUE_STRING)
+        {
+            String str = jp.getText().trim();
+            if (str.isEmpty())
+            {
+                return null;
+            }
+            return YearMonth.parse(str);
+        }
+        throw ctxt.wrongTokenException(jp, JsonToken.VALUE_STRING, "expected JSON String");
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
@@ -386,4 +386,54 @@ public class JodaDeserializationTest extends JodaTestBase
         assertNull(MAPPER.readValue(quote(""), Instant.class));
     }
 
+    public void testDeserMonthDay() throws Exception
+    {
+        String monthDayString = new MonthDay(7, 23).toString();
+        MonthDay monthDay = MAPPER.readValue(quote(monthDayString), MonthDay.class);
+        assertEquals(new MonthDay(7, 23), monthDay);
+    }
+
+    public void testDeserMonthDayFromEmptyString() throws Exception
+    {
+        MonthDay monthDay = MAPPER.readValue(quote(""), MonthDay.class);
+        assertNull(monthDay);
+    }
+
+    public void testDeserMonthDayFailsForUnexpectedType() throws IOException
+    {
+        try
+        {
+            MAPPER.readValue("{\"month\":8}", MonthDay.class);
+            fail();
+        } catch (JsonMappingException e)
+        {
+            assertTrue(e.getMessage().contains("expected JSON String"));
+        }
+    }
+
+    public void testDeserYearMonth() throws Exception
+    {
+        String yearMonthString = new YearMonth(2013, 8).toString();
+        YearMonth yearMonth = MAPPER.readValue(quote(yearMonthString), YearMonth.class);
+        assertEquals(new YearMonth(2013, 8), yearMonth);
+    }
+
+    public void testDeserYearMonthFromEmptyString() throws Exception
+    {
+        YearMonth yearMonth = MAPPER.readValue(quote(""), YearMonth.class);
+        assertNull(yearMonth);
+    }
+
+    public void testDeserYearMonthFailsForUnexpectedType() throws IOException
+    {
+        try
+        {
+            MAPPER.readValue("{\"year\":2013}", YearMonth.class);
+            fail();
+        } catch (JsonMappingException e)
+        {
+            assertTrue(e.getMessage().contains("expected JSON String"));
+        }
+    }
+
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaSerializationTest.java
@@ -239,4 +239,21 @@ public class JodaSerializationTest extends JodaTestBase
         m.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         assertEquals(quote("1970-01-01T00:00:00.000Z"), m.writeValueAsString(instant));
     }
+
+    public void testMonthDaySer() throws Exception
+    {
+        MonthDay monthDay = new MonthDay(7, 23);
+        ObjectMapper mapper = jodaMapper();
+        String json = mapper.writeValueAsString(monthDay);
+        assertEquals(quote("--07-23"), json);
+    }
+
+    public void testYearMonthSer() throws Exception
+    {
+        YearMonth yearMonth = new YearMonth(2013, 8);
+        ObjectMapper mapper = jodaMapper();
+        String json = mapper.writeValueAsString(yearMonth);
+        assertEquals(quote("2013-08"), json);
+    }
+
 }


### PR DESCRIPTION
I have created serializers and deserializers for org.joda.time.MonthDay and org.joda.time.YearMonth which use the appropriate ISO8601 date sub string.

I am not sure what the policy for backwards compatibility is so I have not attempted to handle deserializing objects which have been serialized with a previous version of the JodaModule.
