### PR TITLE
Added a DateTime KeyDeserializer to JodaModule.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
@@ -38,5 +38,8 @@ public class JodaModule extends SimpleModule
         addSerializer(LocalTime.class, new LocalTimeSerializer());
         addSerializer(Period.class, ToStringSerializer.instance);
         addSerializer(Interval.class, new IntervalSerializer());
+
+        // then key deserializers - only one included for DateTime here.
+        addKeyDeserializer(DateTime.class, new DateTimeKeyDeserializer());
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeKeyDeserializer.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.datatype.joda.deser;
+
+import java.io.IOException;
+
+import org.joda.time.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+
+public class DateTimeKeyDeserializer extends KeyDeserializer {
+
+  @Override
+  public Object deserializeKey(final String key, final DeserializationContext ctxt) throws IOException,
+      JsonProcessingException {
+    if (key.length() == 0) { // [JACKSON-360]
+        return null;
+    }
+    return new DateTime(key, DateTimeZone.forTimeZone(ctxt.getTimeZone()));
+  }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaDeserializationTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.datatype.joda;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.*;
@@ -8,6 +9,7 @@ import org.joda.time.*;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Map;
 import java.util.TimeZone;
 
 /**
@@ -384,6 +386,15 @@ public class JodaDeserializationTest extends JodaTestBase
 
         // since 1.6.1, for [JACKSON-360]
         assertNull(MAPPER.readValue(quote(""), Instant.class));
+    }
+
+    public void testDateTimeKeyDeserialize() throws IOException {
+
+        final String json = "{" + quote("1970-01-01T00:00:00.000Z") + ":0}";
+        final Map<DateTime, Long> map = MAPPER.readValue(json, new TypeReference<Map<DateTime, String>>() { });
+
+        assertNotNull(map);
+        assertTrue(map.containsKey(DateTime.parse("1970-01-01T00:00:00.000Z")));
     }
 
 }


### PR DESCRIPTION
As it stands, if Joda objects are stored as keys in `Map`s the deserialization should be handled by the developer. This pull request allows `Map`s with `DateTime` keys to be deserialized with JodaModule (by adding a `DateTime` `KeyDeserializer`). If including this pull request looks like a good idea I will produce a more detailed pull request with `KeyDeserializer`s for all Joda objects. As such, this is more of a proof-of-concept. I have also included a test for key deserialization. 
