### PR TITLE
add hashCode and equals to Module.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
@@ -39,4 +39,16 @@ public class JodaModule extends SimpleModule
         addSerializer(Period.class, ToStringSerializer.instance);
         addSerializer(Interval.class, new IntervalSerializer());
     }
+
+    @Override
+    public int hashCode()
+    {
+        return JodaModule.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        return this == o;
+    }
 }


### PR DESCRIPTION
This ensures that a set which collects modules only contains one
instance of the JodaModule.
