### PR TITLE
Added a writeDatesAsTimestamps property to the JodaMapper

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/JodaMapper.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/JodaMapper.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.datatype.joda;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 public class JodaMapper extends ObjectMapper
 {
@@ -8,5 +9,13 @@ public class JodaMapper extends ObjectMapper
 
     public JodaMapper() {
         registerModule(new JodaModule());
+    }
+
+    public boolean getWriteDatesAsTimestamps() {
+        return getSerializationConfig().isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    public void setWriteDatesAsTimestamps(boolean writeDatesAsTimestamps) {
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, writeDatesAsTimestamps);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaMapperTest.java
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.datatype.joda;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JodaMapperTest
+{
+    @Test
+    public void test_writeDatesAsTimestamps_property()
+    {
+        JodaMapper objectUnderTest = new JodaMapper();
+
+        objectUnderTest.setWriteDatesAsTimestamps(true);
+        assertThat(objectUnderTest.getWriteDatesAsTimestamps(), is(true));
+
+        objectUnderTest.setWriteDatesAsTimestamps(false);
+        assertThat(objectUnderTest.getWriteDatesAsTimestamps(), is(false));
+    }
+
+    @Test
+    public void setWriteDatesAsTimestamps_sets_the_WRITE_DATES_AS_TIMESTAMPS_configuration()
+    {
+        JodaMapper objectUnderTest = new JodaMapper();
+
+        objectUnderTest.setWriteDatesAsTimestamps(true);
+
+        assertThat(objectUnderTest.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS), is(true));
+    }
+}


### PR DESCRIPTION
Since the WRITE_DATES_AS_TIMESTAMPS SerializationFeature is highly related to the JodaMapper, I added a property on JodaMapper to set this configuration.

This also has the benefit of making Spring configuration much simpler.

```
<bean id="jsonObjectMapper" class="com.fasterxml.jackson.datatype.joda.JodaMapper">
    <property name="writeDateKeysAsTimestamps">
        <value type="java.lang.Boolean">false</value>
    </property>
</bean>
```
