### PR TITLE
Fixed name typo in CREDITS

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -24,7 +24,6 @@ Brad Kennedy (bkenned4@github)
  * Contributed #45: Can't use LocalTime, LocalDate & LocalDateTime as Key type for a Map
   (2.4.3)
 
-Charlie La Mother (clamothe@github)
-
+Charlie La Mothe (clamothe@github)
  * Contributed #51: Calling `JodaDateSerializerBase.isEmpty()` results in a `StackOverflowError`.
   (2.5.1)


### PR DESCRIPTION
I noticed an extra letter on my last name. In case it's important for your legal documents, here's a fix. Thanks for the quick merge of the fix.