### PR TITLE
On StackOverflow I have answered for question: How to deserialize from

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
@@ -22,14 +22,14 @@ public class LocalDateDeserializer
     @Override
     public LocalDate deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException
     {
-        // [yyyy,mm,dd]
+        // [yyyy,mm,dd] or ["yyyy","mm","dd"]
         if (jp.isExpectedStartArrayToken()) {
-            jp.nextToken(); // VALUE_NUMBER_INT 
-            int year = jp.getIntValue(); 
-            jp.nextToken(); // VALUE_NUMBER_INT
-            int month = jp.getIntValue();
-            jp.nextToken(); // VALUE_NUMBER_INT
-            int day = jp.getIntValue();
+            jp.nextToken(); // VALUE_NUMBER_INT or VALUE_STRING
+            int year = new Integer(jp.getText());
+            jp.nextToken(); // VALUE_NUMBER_INT or VALUE_STRING
+            int month = new Integer(jp.getText());
+            jp.nextToken(); // VALUE_NUMBER_INT or VALUE_STRING
+            int day = new Integer(jp.getText());
             if (jp.nextToken() != JsonToken.END_ARRAY) {
                 throw ctxt.wrongTokenException(jp, JsonToken.END_ARRAY, "after LocalDate ints");
             }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
@@ -183,6 +183,15 @@ public class MiscDeserializationTest extends JodaTestBase
         assertEquals(7, date2.getMonthOfYear());
         assertEquals(13, date2.getDayOfMonth());
     }
+
+    public void testLocalDateDeserWithPartsAsString() throws IOException
+    {
+        // couple of acceptable formats, so:
+        LocalDate date = MAPPER.readValue("[\"2001\",\"5\",\"25\"]", LocalDate.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+    }
     
     /*
     /**********************************************************


### PR DESCRIPTION
JSON to LocalDate, while also using
JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS?
(http://stackoverflow.com/questions/24432828/how-to-deserialize-from-jso
n-to-localdate-while-also-using-jsongenerator-featur)

I fixed it changing LocalDateDeserializer:
1. I have replaced “jp.getIntValue()” with “new Integer(jp.getText())”
which allows read integers and string tokens in the same way.
2. I added test for this change.