### PR TITLE
Fixed issue 49

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
@@ -116,14 +116,8 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
 
     public DateTimeFormatter createFormatter(SerializerProvider provider)
     {
-        DateTimeFormatter formatter = _formatter;
-        
-        if (!_explicitLocale) {
-            Locale loc = provider.getLocale();
-            if (loc != null && !loc.equals(_locale)) {
-                formatter = formatter.withLocale(loc);
-            }
-        }
+        DateTimeFormatter formatter = createFormatterWithLocale(provider);
+
         if (!_explicitTimezone) {
             TimeZone tz = provider.getTimeZone();
             if (tz != null && !tz.equals(_jdkTimezone)) {
@@ -131,6 +125,20 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
             }
         }
         
+        return formatter;
+    }
+
+    public DateTimeFormatter createFormatterWithLocale(SerializerProvider provider)
+    {
+        DateTimeFormatter formatter = _formatter;
+
+        if (!_explicitLocale) {
+            Locale loc = provider.getLocale();
+            if (loc != null && !loc.equals(_locale)) {
+                formatter = formatter.withLocale(loc);
+            }
+        }
+
         return formatter;
     }
     

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateMidnightSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateMidnightSerializer.java
@@ -15,7 +15,7 @@ public final class DateMidnightSerializer
 {
     private static final long serialVersionUID = 1L;
 
-    public DateMidnightSerializer() { this(FormatConfig.DEFAULT_DATEONLY_FORMAT); }
+    public DateMidnightSerializer() { this(FormatConfig.DEFAULT_LOCAL_DATEONLY_FORMAT); }
     public DateMidnightSerializer(JacksonJodaDateFormat format) {
         // true -> use arrays
         super(DateMidnight.class, format, true,
@@ -44,7 +44,7 @@ public final class DateMidnightSerializer
             jgen.writeNumber(value.dayOfMonth().get());
             jgen.writeEndArray();
         } else {
-            jgen.writeString(_format.createFormatter(provider).print(value));
+            jgen.writeString(_format.createFormatterWithLocale(provider).print(value));
         }
     }
 }


### PR DESCRIPTION
Fixed issue #49

1. Used DEFAULT_LOCAL_DATEONLY_FORMAT instead DEFAULT_DATEONLY_FORMAT in default DateMidnightSerializer constructor.
2. Splitted  createFormatter method on two where one recreates formatter using locale only and other recreates formatter using locale and time zone.
