### PR TITLE
Test failure in DateTimeTest.testCustomPatternStyle with a non english locale

### DIFF
--- a/src/test/java/com/fasterxml/jackson/datatype/joda/DateTimeTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/DateTimeTest.java
@@ -20,7 +20,7 @@ public class DateTimeTest extends JodaTestBase
 
     static class CustomDate {
         // note: 'SS' means 'short representation'
-        @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="SS")
+        @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="SS", locale="en")
         public DateTime date;
 
         public CustomDate(DateTime d) {


### PR DESCRIPTION
DateTimeTest.testCustomPatternStyle fails with a non English locale:

    Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.383 sec <<< FAILURE! - in com.fasterxml.jackson.datatype.joda.DateTimeTest
    testCustomPatternStyle(com.fasterxml.jackson.datatype.joda.DateTimeTest)  Time elapsed: 0.008 sec  <<< FAILURE!
    junit.framework.ComparisonFailure: expected:<{"date":"[1/1/70 12:00 AM]"}> but was:<{"date":"[01/01/70 00:00]"}>
            at junit.framework.Assert.assertEquals(Assert.java:100)
            at junit.framework.Assert.assertEquals(Assert.java:107)
            at junit.framework.TestCase.assertEquals(TestCase.java:269)
            at com.fasterxml.jackson.datatype.joda.DateTimeTest.testCustomPatternStyle(DateTimeTest.java:101)

Here is a trivial patch fixing this issue.