### PR TITLE
Add TimeZone consideration for DateMidnight and Interval

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/FormatConfig.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/FormatConfig.java
@@ -1,10 +1,8 @@
 package com.fasterxml.jackson.datatype.joda.cfg;
 
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.joda.time.format.ISOPeriodFormat;
-import org.joda.time.format.PeriodFormatter;
 
 /**
  * Simple container class that holds both default formatter information

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
@@ -48,7 +48,7 @@ public class DateMidnightDeserializer
                 throw ctxt.wrongTokenException(p, JsonToken.END_ARRAY,
                         "after DateMidnight ints");
             }
-            return new DateMidnight(year, month, day);
+            return new DateMidnight(year, month, day, getDateTimeZone(ctxt));
         }
         switch (p.getCurrentToken()) {
         case VALUE_NUMBER_INT:

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
@@ -1,14 +1,18 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
+import java.io.IOException;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
-
-import org.joda.time.*;
-
-import java.io.IOException;
-import java.util.TimeZone;
 
 /**
  * Basic deserializer for {@link ReadableDateTime} and its subtypes.
@@ -43,9 +47,8 @@ public class DateTimeDeserializer
         JsonToken t = p.getCurrentToken();
 
         if (t == JsonToken.VALUE_NUMBER_INT) {
-            TimeZone tz = ctxt.getTimeZone();
-            DateTimeZone dtz = (tz == null) ? DateTimeZone.UTC : DateTimeZone.forTimeZone(tz);
-            return new DateTime(p.getLongValue(), dtz);
+            DateTimeZone dtz = getDateTimeZone(ctxt);
+            return new DateTime(p.getLongValue(), dtz == null ? DateTimeZone.UTC : dtz);
         }
         if (t == JsonToken.VALUE_STRING) {
             String str = p.getText().trim();

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
@@ -53,6 +53,6 @@ public class IntervalDeserializer extends JodaDeserializerBase<Interval>
             throw JsonMappingException.from(jsonParser,
                     "Failed to parse number from '"+str+"' (full source String '"+v+"') to construct "+handledType().getName());
         }
-        return new Interval(start, end);
+        return new Interval(start, end, getDateTimeZone(deserializationContext));
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/JodaDeserializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/JodaDeserializerBase.java
@@ -2,7 +2,10 @@ package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.core.*;
+import org.joda.time.DateTimeZone;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
@@ -21,5 +24,12 @@ abstract class JodaDeserializerBase<T> extends StdScalarDeserializer<T>
     @Override
     public Object deserializeWithType(JsonParser jp, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException, JsonProcessingException {
         return typeDeserializer.deserializeTypedFromAny(jp, ctxt);
+    }
+
+    protected DateTimeZone getDateTimeZone(final DeserializationContext ctxt) {
+    	if (ctxt.getTimeZone() == null) {
+    		return null;
+    	}
+    	return DateTimeZone.forTimeZone(ctxt.getTimeZone());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/DateMidnightTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/DateMidnightTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.datatype.joda;
 
 import java.io.IOException;
+import java.util.TimeZone;
 
 import org.joda.time.DateMidnight;
 
@@ -35,6 +36,40 @@ public class DateMidnightTest extends JodaTestBase
     /**********************************************************
      */
 
+    public void testDateMidnightDeserWithTimeZone() throws IOException
+    {
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+        // couple of acceptable formats, so:
+        DateMidnight date = MAPPER.readValue("[2001,5,25]", DateMidnight.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        DateMidnight date2 = MAPPER.readValue(quote("2005-07-13"), DateMidnight.class);
+        assertEquals(2005, date2.getYear());
+        assertEquals(7, date2.getMonthOfYear());
+        assertEquals(13, date2.getDayOfMonth());
+
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), DateMidnight.class));
+
+        
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        // couple of acceptable formats, so:
+        date = MAPPER.readValue("[2001,5,25]", DateMidnight.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        date2 = MAPPER.readValue(quote("2005-07-13"), DateMidnight.class);
+        assertEquals(2005, date2.getYear());
+        assertEquals(7, date2.getMonthOfYear());
+        assertEquals(13, date2.getDayOfMonth());
+
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), DateMidnight.class));
+    }
+    
     public void testDateMidnightDeser() throws IOException
     {
         // couple of acceptable formats, so:

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/IntervalSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/IntervalSerializationTest.java
@@ -5,8 +5,9 @@ import java.io.IOException;
 import org.joda.time.Interval;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 public class IntervalSerializationTest extends JodaTestBase
 {
@@ -47,5 +48,4 @@ public class IntervalSerializationTest extends JodaTestBase
         assertEquals("[\"org.joda.time.Interval\"," + quote("1396439982-1396440001") + "]",
                 mapper.writeValueAsString(interval));
     }
-
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
@@ -1,19 +1,32 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.Interval;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
+import org.joda.time.MonthDay;
+import org.joda.time.Period;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
+import org.joda.time.YearMonth;
+import org.joda.time.chrono.ISOChronology;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaTestBase;
-
-import org.joda.time.*;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * Unit tests for verifying limited interoperability for Joda time.
@@ -113,6 +126,32 @@ public class MiscDeserializationTest extends JodaTestBase
     /**********************************************************
      */
 
+	/**
+	 * LocalDate is supposed to be without timezone, so it doesn't matter how it is set.
+	 */
+	public void testLocalDateDeserWithTimeZone() throws IOException 
+	{
+		MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+
+		// couple of acceptable formats, so:
+		LocalDate date = MAPPER.readValue("[2001,5,25]", LocalDate.class);
+		assertEquals(2001, date.getYear());
+		assertEquals(5, date.getMonthOfYear());
+		assertEquals(25, date.getDayOfMonth());
+		assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+		MAPPER.setTimeZone(TimeZone.getTimeZone("Asia/Taipei"));
+		LocalDate date2 = MAPPER
+				.readValue(quote("2005-07-13"), LocalDate.class);
+		assertEquals(2005, date2.getYear());
+		assertEquals(7, date2.getMonthOfYear());
+		assertEquals(13, date2.getDayOfMonth());
+		assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+		// since 1.6.1, for [JACKSON-360]
+		assertNull(MAPPER.readValue(quote(""), LocalDate.class));
+	}
+    
     public void testLocalDateDeser() throws IOException
     {
         // couple of acceptable formats, so:
@@ -216,6 +255,25 @@ public class MiscDeserializationTest extends JodaTestBase
         assertEquals(1396440001, interval.getEndMillis());
     }
 
+    public void testIntervalDeserWithTimeZone() throws IOException
+    {
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+
+        Interval interval = MAPPER.readValue(quote("1396439982-1396440001"), Interval.class);
+        assertEquals(1396439982, interval.getStartMillis());
+        assertEquals(1396440001, interval.getEndMillis());
+        assertEquals(ISOChronology.getInstance(DateTimeZone.forID("Europe/Paris")), interval.getChronology());
+
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+
+        interval = MAPPER.readValue(quote("-100-1396440001"), Interval.class);
+        assertEquals(-100, interval.getStartMillis());
+        assertEquals(1396440001, interval.getEndMillis());
+        assertEquals(ISOChronology.getInstance(DateTimeZone.forID("America/Los_Angeles")), interval.getChronology());
+
+    }
+
+    
     public void testIntervalDeserWithTypeInfo() throws IOException
     {
         ObjectMapper mapper = jodaMapper();
@@ -232,6 +290,39 @@ public class MiscDeserializationTest extends JodaTestBase
     /**********************************************************
      */
 
+
+    public void testLocalDateTimeDeserWithTimeZone() throws IOException
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        
+        // couple of acceptable formats again:
+        LocalDateTime date = MAPPER.readValue("[2001,5,25,10,15,30,37]", LocalDateTime.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        assertEquals(10, date.getHourOfDay());
+        assertEquals(15, date.getMinuteOfHour());
+        assertEquals(30, date.getSecondOfMinute());
+        assertEquals(37, date.getMillisOfSecond());
+        assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+        MAPPER.setTimeZone(TimeZone.getTimeZone("Asia/Taipei"));
+        LocalDateTime date2 = MAPPER.readValue(quote("2007-06-30T08:34:09.001"), LocalDateTime.class);
+        assertEquals(2007, date2.getYear());
+        assertEquals(6, date2.getMonthOfYear());
+        assertEquals(30, date2.getDayOfMonth());
+
+        assertEquals(8, date2.getHourOfDay());
+        assertEquals(34, date2.getMinuteOfHour());
+        assertEquals(9, date2.getSecondOfMinute());
+        assertEquals(1, date2.getMillisOfSecond());
+        assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+        
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), LocalDateTime.class));
+    }
+    
     public void testLocalDateTimeDeser() throws IOException
     {
         // couple of acceptable formats again:
@@ -429,6 +520,17 @@ public class MiscDeserializationTest extends JodaTestBase
         assertTrue(map.containsKey(LocalDateTime.parse("2014-05-23T00:00:00.000")));
     }
 
+    public void testDeserMonthDayWithTimeZone() throws Exception
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+        
+        String monthDayString = new MonthDay(7, 23).toString();
+        MonthDay monthDay = MAPPER.readValue(quote(monthDayString), MonthDay.class);
+        assertEquals(new MonthDay(7, 23), monthDay);
+        
+        assertEquals(ISOChronology.getInstanceUTC(), monthDay.getChronology());
+    }
+    
     public void testDeserMonthDay() throws Exception
     {
         String monthDayString = new MonthDay(7, 23).toString();
@@ -454,6 +556,16 @@ public class MiscDeserializationTest extends JodaTestBase
         }
     }
 
+    public void testDeserYearMonthWithTimeZone() throws Exception
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        
+        String yearMonthString = new YearMonth(2013, 8).toString();
+        YearMonth yearMonth = MAPPER.readValue(quote(yearMonthString), YearMonth.class);
+        assertEquals(new YearMonth(2013, 8), yearMonth);
+        assertEquals(ISOChronology.getInstanceUTC(), yearMonth.getChronology());
+    }
+    
     public void testDeserYearMonth() throws Exception
     {
         String yearMonthString = new YearMonth(2013, 8).toString();


### PR DESCRIPTION
This pull request is to address #58 

Essentially there are only following datatypes that need to handle ``TimeZone`` from ``DeserializationContext``:
   1. ``DateTime``: Already handled.  Consolidate the way it is handled.
   2. ``DateMidnight``: Adding ``TimeZone`` information into ``DateMidnight``
   3. ``Interval``: Adding ``TimeZone`` information into ``Interval``

The rest are not relevant since they are either defaulted as UTC or conceptually not applicable.  I still add unit test cases just to make sure.

Also adding more unit test cases for modified code.  All unit test cases are passing.  Backward compatibility should not be an issue.