### PR TITLE
Use TimeZone in DeserializationContext when SerializationFeature.WRITE_DATES_WITH_ZONE_ID is not set

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/FormatConfig.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/FormatConfig.java
@@ -1,7 +1,8 @@
 package com.fasterxml.jackson.datatype.joda.cfg;
 
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.*;
+import org.joda.time.format.ISODateTimeFormat;
+import org.joda.time.format.ISOPeriodFormat;
 
 /**
  * Simple container class that holds both default formatter information

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
@@ -198,6 +198,14 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
         }
         return formatter;
     }
+
+    /**
+     * Differentiate if TimeZone is specified by caller 
+     * @return true if TimeZone is specified by caller; false otherwise.
+     */
+    public boolean isTimezoneExplicit() {
+    	return _explicitTimezone;
+    }
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.joda.deser;
 import java.io.IOException;
 
 import org.joda.time.DateMidnight;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -36,6 +37,7 @@ public class DateMidnightDeserializer
     public DateMidnight deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException
     {
+    	
         // We'll accept either long (timestamp) or array:
         if (p.isExpectedStartArrayToken()) {
             p.nextToken(); // VALUE_NUMBER_INT
@@ -48,7 +50,9 @@ public class DateMidnightDeserializer
                 throw ctxt.wrongTokenException(p, JsonToken.END_ARRAY,
                         "after DateMidnight ints");
             }
-            return new DateMidnight(year, month, day);
+            DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
+
+            return new DateMidnight(year, month, day, tz);
         }
         switch (p.getCurrentToken()) {
         case VALUE_NUMBER_INT:

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
@@ -1,14 +1,18 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
+import java.io.IOException;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
-
-import org.joda.time.*;
-
-import java.io.IOException;
-import java.util.TimeZone;
 
 /**
  * Basic deserializer for {@link ReadableDateTime} and its subtypes.
@@ -42,10 +46,10 @@ public class DateTimeDeserializer
     {
         JsonToken t = p.getCurrentToken();
 
+        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
+        
         if (t == JsonToken.VALUE_NUMBER_INT) {
-            TimeZone tz = ctxt.getTimeZone();
-            DateTimeZone dtz = (tz == null) ? DateTimeZone.UTC : DateTimeZone.forTimeZone(tz);
-            return new DateTime(p.getLongValue(), dtz);
+            return new DateTime(p.getLongValue(), tz);
         }
         if (t == JsonToken.VALUE_STRING) {
             String str = p.getText().trim();
@@ -60,7 +64,6 @@ public class DateTimeDeserializer
                 String tzId = (ix2 < ix)
                         ? str.substring(ix+1)
                         : str.substring(ix+1, ix2);
-                DateTimeZone tz;
                 try {
                     tz = DateTimeZone.forID(tzId);
                 } catch (IllegalArgumentException e) {
@@ -87,16 +90,5 @@ public class DateTimeDeserializer
             return _format.createParser(ctxt).parseDateTime(str);
         }
         throw ctxt.mappingException(handledType());
-    }
-
-    private static boolean _allDigits(String str)
-    {
-        for (int i = 0, len = str.length(); i < len; ++i) {
-            int c = str.charAt(i);
-            if (c > '9' | c < '0') {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
@@ -2,15 +2,15 @@ package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
 
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
-
-import org.joda.time.*;
 
 public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
 {
@@ -64,7 +64,8 @@ public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
             throw JsonMappingException.from(jsonParser,
                     "Failed to parse number from '"+str+"' (full source String '"+v+"') to construct "+handledType().getName());
         }
-        DateTimeZone tz = _format.getTimeZone();
+        
+        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
         if (tz != null) {
             if (!tz.equals(result.getStart().getZone())) {
                 result = new Interval(result.getStartMillis(), result.getEndMillis(), tz);

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserializer.java
@@ -4,7 +4,8 @@ import java.io.IOException;
 
 import org.joda.time.LocalTime;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/DateTimeKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/DateTimeKeyDeserializer.java
@@ -3,7 +3,8 @@ package com.fasterxml.jackson.datatype.joda.deser.key;
 import java.io.IOException;
 import java.util.TimeZone;
 
-import org.joda.time.*;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeZoneSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeZoneSerializer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.joda.time.DateTimeZone;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 public class DateTimeZoneSerializer extends JodaSerializerBase<DateTimeZone>

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DurationSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DurationSerializer.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import org.joda.time.Duration;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/InstantSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/InstantSerializer.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.datatype.joda.ser;
 
 import java.io.IOException;
 
-import org.joda.time.*;
+import org.joda.time.Instant;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializerBase.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.datatype.joda.ser;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/LocalTimeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/LocalTimeSerializer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.joda.time.LocalTime;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/DateMidnightTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/DateMidnightTest.java
@@ -1,8 +1,10 @@
 package com.fasterxml.jackson.datatype.joda;
 
 import java.io.IOException;
+import java.util.TimeZone;
 
 import org.joda.time.DateMidnight;
+import org.joda.time.DateTimeZone;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -29,12 +31,51 @@ public class DateMidnightTest extends JodaTestBase
         }
     }
     
+    static class FormattedDateMidnight {
+        @JsonFormat(timezone="EST")
+        public DateMidnight dateMidnight;
+    }
+    
     /*
     /**********************************************************
     /* Test methods
     /**********************************************************
      */
 
+    public void testDateMidnightDeserWithTimeZone() throws IOException
+    {
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+        // couple of acceptable formats, so:
+        DateMidnight date = MAPPER.readValue("[2001,5,25]", DateMidnight.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        DateMidnight date2 = MAPPER.readValue(quote("2005-07-13"), DateMidnight.class);
+        assertEquals(2005, date2.getYear());
+        assertEquals(7, date2.getMonthOfYear());
+        assertEquals(13, date2.getDayOfMonth());
+
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), DateMidnight.class));
+
+        
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        // couple of acceptable formats, so:
+        date = MAPPER.readValue("[2001,5,25]", DateMidnight.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        date2 = MAPPER.readValue(quote("2005-07-13"), DateMidnight.class);
+        assertEquals(2005, date2.getYear());
+        assertEquals(7, date2.getMonthOfYear());
+        assertEquals(13, date2.getDayOfMonth());
+
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), DateMidnight.class));
+    }
+    
     public void testDateMidnightDeser() throws IOException
     {
         // couple of acceptable formats, so:
@@ -84,5 +125,28 @@ public class DateMidnightTest extends JodaTestBase
         AlternateFormat output = MAPPER.readValue(json, AlternateFormat.class);
         assertNotNull(output.value);
         assertEquals(inputDate, output.value);
+    }
+    
+    public void testWithTimeZoneOverride() throws Exception
+    {
+        ObjectMapper mapper = jodaMapper();
+
+        DateMidnight date = mapper.readValue("[2001,5,25]", DateMidnight.class);
+        FormattedDateMidnight input = new FormattedDateMidnight();
+        input.dateMidnight = date;
+        String json = mapper.writeValueAsString(input);
+
+        FormattedDateMidnight result = mapper.readValue(json, FormattedDateMidnight.class);
+        assertNotNull(result);
+
+        // Ensure timezone sticks:
+        DateMidnight resultMidnight = result.dateMidnight;
+        assertEquals(2001, resultMidnight.getYear());
+        assertEquals(5, resultMidnight.getMonthOfYear());
+        assertEquals(25, resultMidnight.getDayOfMonth());
+
+        DateTimeZone resultTz = resultMidnight.getZone();
+        // Is this stable enough for testing?
+        assertEquals("America/New_York", resultTz.getID());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/DateTimeTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/DateTimeTest.java
@@ -2,10 +2,15 @@ package com.fasterxml.jackson.datatype.joda;
 
 import java.io.IOException;
 
-import org.joda.time.*;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 public class DateTimeTest extends JodaTestBase
 {
@@ -47,6 +52,11 @@ public class DateTimeTest extends JodaTestBase
           this.jodaDateTime = jodaDateTime;
           this.javaUtilDate = javaUtilDate;
         }
+    }
+    
+    static class FormattedDateTime {
+        @JsonFormat(timezone="EST")
+        public DateTime dateTime;
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY, property = "@class")
@@ -158,5 +168,29 @@ public class DateTimeTest extends JodaTestBase
         assertNotNull(output.date);
         // Timezone may (and most likely will) differ so...
         assertEquals(inputDate.getMillis(), output.date.getMillis());
+    }
+    
+    public void testWithTimeZoneOverride() throws Exception
+    {
+        ObjectMapper mapper = jodaMapper();
+
+        DateTime date = mapper.readValue(quote("2014-01-20T08:59:01.000-0500"), DateTime.class);
+
+        FormattedDateTime input = new FormattedDateTime();
+        input.dateTime = date;
+        String json = mapper.writeValueAsString(input);
+
+        FormattedDateTime result = mapper.readValue(json, FormattedDateTime.class);
+        assertNotNull(result);
+
+        // Ensure timezone sticks:
+        DateTime resultMidnight = result.dateTime;
+        assertEquals(2014, resultMidnight.getYear());
+        assertEquals(1, resultMidnight.getMonthOfYear());
+        assertEquals(20, resultMidnight.getDayOfMonth());
+
+        DateTimeZone resultTz = resultMidnight.getZone();
+        // Is this stable enough for testing?
+        assertEquals("America/New_York", resultTz.getID());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
@@ -1,19 +1,32 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.Interval;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
+import org.joda.time.MonthDay;
+import org.joda.time.Period;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
+import org.joda.time.YearMonth;
+import org.joda.time.chrono.ISOChronology;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaTestBase;
-
-import org.joda.time.*;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * Unit tests for verifying limited interoperability for Joda time.
@@ -130,6 +143,29 @@ public class MiscDeserializationTest extends JodaTestBase
         assertNull(MAPPER.readValue(quote(""), LocalDate.class));
     }
 
+	public void testLocalDateDeserWithTimeZone() throws IOException 
+	{
+		MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+
+		// couple of acceptable formats, so:
+		LocalDate date = MAPPER.readValue("[2001,5,25]", LocalDate.class);
+		assertEquals(2001, date.getYear());
+		assertEquals(5, date.getMonthOfYear());
+		assertEquals(25, date.getDayOfMonth());
+		assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+		MAPPER.setTimeZone(TimeZone.getTimeZone("Asia/Taipei"));
+		LocalDate date2 = MAPPER
+				.readValue(quote("2005-07-13"), LocalDate.class);
+		assertEquals(2005, date2.getYear());
+		assertEquals(7, date2.getMonthOfYear());
+		assertEquals(13, date2.getDayOfMonth());
+		assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+		// since 1.6.1, for [JACKSON-360]
+		assertNull(MAPPER.readValue(quote(""), LocalDate.class));
+	}
+    
     public void testLocalDateDeserWithTypeInfo() throws IOException
     {
         ObjectMapper mapper = jodaMapper();
@@ -214,8 +250,28 @@ public class MiscDeserializationTest extends JodaTestBase
         interval = MAPPER.readValue(quote("-100-1396440001"), Interval.class);
         assertEquals(-100, interval.getStartMillis());
         assertEquals(1396440001, interval.getEndMillis());
+        
+        assertEquals(ISOChronology.getInstance(DateTimeZone.UTC), interval.getChronology());
     }
 
+    public void testIntervalDeserWithTimeZone() throws IOException
+    {
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+
+        Interval interval = MAPPER.readValue(quote("1396439982-1396440001"), Interval.class);
+        assertEquals(1396439982, interval.getStartMillis());
+        assertEquals(1396440001, interval.getEndMillis());
+        assertEquals(ISOChronology.getInstance(DateTimeZone.forID("Europe/Paris")), interval.getChronology());
+
+    	MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+
+        interval = MAPPER.readValue(quote("-100-1396440001"), Interval.class);
+        assertEquals(-100, interval.getStartMillis());
+        assertEquals(1396440001, interval.getEndMillis());
+        assertEquals(ISOChronology.getInstance(DateTimeZone.forID("America/Los_Angeles")), interval.getChronology());
+
+    }
+    
     public void testIntervalDeserWithTypeInfo() throws IOException
     {
         ObjectMapper mapper = jodaMapper();
@@ -259,6 +315,38 @@ public class MiscDeserializationTest extends JodaTestBase
         assertNull(MAPPER.readValue(quote(""), LocalDateTime.class));
     }
 
+    public void testLocalDateTimeDeserWithTimeZone() throws IOException
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        
+        // couple of acceptable formats again:
+        LocalDateTime date = MAPPER.readValue("[2001,5,25,10,15,30,37]", LocalDateTime.class);
+        assertEquals(2001, date.getYear());
+        assertEquals(5, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+
+        assertEquals(10, date.getHourOfDay());
+        assertEquals(15, date.getMinuteOfHour());
+        assertEquals(30, date.getSecondOfMinute());
+        assertEquals(37, date.getMillisOfSecond());
+        assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+
+        MAPPER.setTimeZone(TimeZone.getTimeZone("Asia/Taipei"));
+        LocalDateTime date2 = MAPPER.readValue(quote("2007-06-30T08:34:09.001"), LocalDateTime.class);
+        assertEquals(2007, date2.getYear());
+        assertEquals(6, date2.getMonthOfYear());
+        assertEquals(30, date2.getDayOfMonth());
+
+        assertEquals(8, date2.getHourOfDay());
+        assertEquals(34, date2.getMinuteOfHour());
+        assertEquals(9, date2.getSecondOfMinute());
+        assertEquals(1, date2.getMillisOfSecond());
+        assertEquals(ISOChronology.getInstanceUTC(), date.getChronology());
+        
+        // since 1.6.1, for [JACKSON-360]
+        assertNull(MAPPER.readValue(quote(""), LocalDateTime.class));
+    }
+    
     public void testLocalDateTimeDeserWithTypeInfo() throws IOException
     {
         ObjectMapper mapper = jodaMapper();
@@ -436,6 +524,17 @@ public class MiscDeserializationTest extends JodaTestBase
         assertEquals(new MonthDay(7, 23), monthDay);
     }
 
+    public void testDeserMonthDayWithTimeZone() throws Exception
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
+        
+        String monthDayString = new MonthDay(7, 23).toString();
+        MonthDay monthDay = MAPPER.readValue(quote(monthDayString), MonthDay.class);
+        assertEquals(new MonthDay(7, 23), monthDay);
+        
+        assertEquals(ISOChronology.getInstanceUTC(), monthDay.getChronology());
+    }
+    
     public void testDeserMonthDayFromEmptyString() throws Exception
     {
         MonthDay monthDay = MAPPER.readValue(quote(""), MonthDay.class);
@@ -461,6 +560,16 @@ public class MiscDeserializationTest extends JodaTestBase
         assertEquals(new YearMonth(2013, 8), yearMonth);
     }
 
+    public void testDeserYearMonthWithTimeZone() throws Exception
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+        
+        String yearMonthString = new YearMonth(2013, 8).toString();
+        YearMonth yearMonth = MAPPER.readValue(quote(yearMonthString), YearMonth.class);
+        assertEquals(new YearMonth(2013, 8), yearMonth);
+        assertEquals(ISOChronology.getInstanceUTC(), yearMonth.getChronology());
+    }
+    
     public void testDeserYearMonthFromEmptyString() throws Exception
     {
         YearMonth yearMonth = MAPPER.readValue(quote(""), YearMonth.class);


### PR DESCRIPTION
Outline
----
This pull request is to fix #68.  It adds a feature to honor ``TimeZone`` in ``DeserializationContext`` if ``SerializationFeature.WRITE_DATES_WITH_ZONE_ID`` is not set.  

If timezone format is specified as part of ``JacksonJodaDateFormat`` during init time, it will be honored first; otherwise ``TimeZone`` in ``DeserializationContext`` is used.

I realize this means if ``JacksonJodaDateFormat`` is predefined as in constructor/``@JsonFormat``, ``TimeZone`` in ``DeserializationContext`` is going to be invalid.  However this ``TimeZone`` has a [default value] (https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/cfg/BaseSettings.java#L119) as .  So that there's no way of distinguishing if this is just a default or this ``TimeZone`` should be handled specifically.  


Fix
----
There are only three datatypes that are associated with ``TimeZone``:
1. DateTime
2. Interval 
3. DateMidnight

```java
DateTimeZone tz = _format.isTimezoneExplicit() ? 
    _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
```

----
Also add additional unit test cases for ``TimeZone`` related features.
