### PR TITLE
Issue #71 fix

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
 
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -37,7 +37,7 @@ public class LocalDateDeserializer
                     : _format.createParser(ctxt).parseLocalDate(str);
         }
         if (p.getCurrentToken() == JsonToken.VALUE_NUMBER_INT) {
-            return new LocalDate(p.getLongValue());            
+            return new LocalDate(p.getLongValue(), DateTimeZone.forTimeZone(ctxt.getTimeZone()));
         }
         
         // [yyyy,mm,dd] or ["yyyy","mm","dd"]

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserializer.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
 
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -38,7 +39,7 @@ public class LocalDateTimeDeserializer
             return (str.length() == 0) ? null
                     : _format.createParser(ctxt).parseLocalDateTime(str);
         case VALUE_NUMBER_INT:
-            return new LocalDateTime(p.getLongValue());            
+            return new LocalDateTime(p.getLongValue(), DateTimeZone.forTimeZone(ctxt.getTimeZone()));
         case START_ARRAY:
             // [yyyy,mm,dd,hh,MM,ss,ms]
             if (p.isExpectedStartArrayToken()) {

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
@@ -143,8 +143,16 @@ public class MiscDeserializationTest extends JodaTestBase
         assertNull(MAPPER.readValue(quote(""), LocalDate.class));
     }
 
-	public void testLocalDateDeserWithTimeZone() throws IOException 
+	public void testLocalDateDeserWithTimeZone() throws IOException
 	{
+    final String trickyInstant = "1238558582001";
+    // MAPPER is using default TimeZone (GMT)
+    LocalDate date3 = MAPPER.readValue(trickyInstant, LocalDate.class);
+    assertEquals(2009, date3.getYear());
+    assertEquals(4, date3.getMonthOfYear());
+    assertEquals(1, date3.getDayOfMonth());
+    assertEquals(ISOChronology.getInstanceUTC(), date3.getChronology());
+
 		MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
 
 		// couple of acceptable formats, so:
@@ -164,6 +172,14 @@ public class MiscDeserializationTest extends JodaTestBase
 
 		// since 1.6.1, for [JACKSON-360]
 		assertNull(MAPPER.readValue(quote(""), LocalDate.class));
+
+    MAPPER.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+
+    LocalDate date4 = MAPPER.readValue(trickyInstant, LocalDate.class);
+    assertEquals(2009, date4.getYear());
+    assertEquals(3, date4.getMonthOfYear());
+    assertEquals(31, date4.getDayOfMonth());
+    assertEquals(ISOChronology.getInstanceUTC(), date4.getChronology());
 	}
     
     public void testLocalDateDeserWithTypeInfo() throws IOException
@@ -313,6 +329,17 @@ public class MiscDeserializationTest extends JodaTestBase
 
         // since 1.6.1, for [JACKSON-360]
         assertNull(MAPPER.readValue(quote(""), LocalDateTime.class));
+
+        // MAPPER is using default TimeZone (GMT)
+        LocalDateTime date3 = MAPPER.readValue("1238558582001", LocalDateTime.class);
+        assertEquals(2009, date3.getYear());
+        assertEquals(4, date3.getMonthOfYear());
+        assertEquals(1, date3.getDayOfMonth());
+        assertEquals(4, date3.getHourOfDay());
+        assertEquals(3, date3.getMinuteOfHour());
+        assertEquals(2, date3.getSecondOfMinute());
+        assertEquals(1, date3.getMillisOfSecond());
+        assertEquals(ISOChronology.getInstanceUTC(), date3.getChronology());
     }
 
     public void testLocalDateTimeDeserWithTimeZone() throws IOException


### PR DESCRIPTION
[#71] use configured TimeZone when deserializing instants (longs) into LocalDate/LocalDateTime