### PR TITLE
Add key deserializers for Duration and Period classes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java
@@ -55,6 +55,8 @@ public class JodaModule extends SimpleModule
         addKeyDeserializer(LocalTime.class, new LocalTimeKeyDeserializer());
         addKeyDeserializer(LocalDate.class, new LocalDateKeyDeserializer());
         addKeyDeserializer(LocalDateTime.class, new LocalDateTimeKeyDeserializer());
+        addKeyDeserializer(Duration.class, new DurationKeyDeserializer());
+        addKeyDeserializer(Period.class, new PeriodKeyDeserializer());
 
         // 26-Dec-2015, tatu: Joda has deprecated following types:
         

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/DurationKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/DurationKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.joda.deser.key;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import org.joda.time.Duration;
+
+import java.io.IOException;
+
+public class DurationKeyDeserializer extends JodaKeyDeserializer {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected Duration deserialize(String key, DeserializationContext ctxt) throws IOException {
+        return Duration.parse(key);
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/PeriodKeyDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/key/PeriodKeyDeserializer.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.datatype.joda.deser.key;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import org.joda.time.Period;
+
+import java.io.IOException;
+
+public class PeriodKeyDeserializer extends JodaKeyDeserializer {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected Period deserialize(String key, DeserializationContext ctxt) throws IOException {
+        return Period.parse(key);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MiscDeserializationTest.java
@@ -543,6 +543,20 @@ public class MiscDeserializationTest extends JodaTestBase
         assertNotNull(map);
         assertTrue(map.containsKey(LocalDateTime.parse("2014-05-23T00:00:00.000")));
     }
+    public void testDurationKeyDeserialize() throws IOException {
+
+        final String json = "{" + quote("PT60s") + ":0}";
+        final Map<Duration, Long> map = MAPPER.readValue(json, new TypeReference<Map<Duration, String>>() { });
+        assertNotNull(map);
+        assertTrue(map.containsKey(Duration.standardMinutes(1L)));
+    }
+    public void testPeriodKeyDeserialize() throws IOException {
+
+        final String json = "{" + quote("PT1H2M3.004S") + ":0}";
+        final Map<Period, Long> map = MAPPER.readValue(json, new TypeReference<Map<Period, String>>() { });
+        assertNotNull(map);
+        assertTrue(map.containsKey(new Period(1, 2, 3, 4)));
+    }
 
     public void testDeserMonthDay() throws Exception
     {


### PR DESCRIPTION
This PR adds [`KeyDeserializer`](https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/KeyDeserializer.html) implementations for Joda-Time's [`Duration`](http://joda-time.sourceforge.net/apidocs/org/joda/time/Duration.html) and [`Period`](http://joda-time.sourceforge.net/apidocs/org/joda/time/Period.html) classes.