### PR TITLE
Change `IntervalDeserializer` to respect input timezone when enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ Joda (http://joda-time.sourceforge.net/) data types.
         <!-- Baseline was 2.2 for Jackson 2.4: no new functionality used from laster
              versions but gradually increasing baseline to get bugfixes etc
           -->
-        <version>2.7</version>
+        <version>2.9</version>
     </dependency>
 
     <!-- and junit for testing -->

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
@@ -59,7 +59,7 @@ public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
         try {
             // !!! TODO: configurable formats...
             if (hasSlash) {
-                result = Interval.parse(v);
+                result = Interval.parseWithOffset(v);
             } else {
                 start = Long.valueOf(str);
                 str = v.substring(index + 1);
@@ -72,7 +72,9 @@ public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
                     str, v);
         }
 
-        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
+        final DateTimeZone contextTimezone =
+            _format.shouldAdjustToContextTimeZone(ctxt) ? DateTimeZone.forTimeZone(ctxt.getTimeZone()) : null;
+        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : contextTimezone;
         if (tz != null) {
             if (!tz.equals(result.getStart().getZone())) {
                 result = new Interval(result.getStartMillis(), result.getEndMillis(), tz);

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.joda.deser;
 import java.io.IOException;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
@@ -63,5 +64,36 @@ public class IntervalDeserTest extends JodaTestBase
         Interval interval= mapper.readValue("[\"org.joda.time.Interval\",\"1396439982-1396440001\"]", Interval.class);
         assertEquals(1396439982, interval.getStartMillis());
         assertEquals(1396440001, interval.getEndMillis());
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithContextTimeZone() throws IOException
+    {
+        MAPPER.setTimeZone(TimeZone.getTimeZone("GMT-2:00"));
+        MAPPER.enable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.forOffsetHours(-2));
+        final Interval actualInterval =
+            MAPPER.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithoutContextTimeZone() throws IOException
+    {
+        MAPPER.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.forOffsetHours(6));
+        final Interval actualInterval =
+            MAPPER.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithDefaultTimeZone() throws IOException
+    {
+        MAPPER.enable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.UTC);
+        final Interval actualInterval =
+            MAPPER.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
     }
 }


### PR DESCRIPTION
Bump dependency on joda-time to v2.9 to access Interval.parseWithOffset
Change `IntervalDeserializer` to use `Interval.parseWithOffset` and
 override timezone only if `shouldAdjustToContextTimeZone` is set or
 explicit timezone is specified in the format
Add unit tests for `IntervalDeserializer` to cover the 3 scenarios:
- Timezone explicitly provided in deserialization format
- Context timezone enabled
- Neither context timezone enabled nor explicit timezone provided
Resolve: https://github.com/FasterXML/jackson-datatype-joda/issues/104