### PR TITLE
Change `IntervalDeserializer` to respect input timezone when enabled

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserializer.java
@@ -57,7 +57,7 @@ public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
         try {
             // !!! TODO: configurable formats...
             if (hasSlash) {
-                result = Interval.parse(v);
+                result = Interval.parseWithOffset(v);
             } else {
                 start = Long.valueOf(str);
                 str = v.substring(index + 1);
@@ -70,7 +70,9 @@ public class IntervalDeserializer extends JodaDateDeserializerBase<Interval>
                     str, v);
         }
 
-        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : DateTimeZone.forTimeZone(ctxt.getTimeZone());
+        final DateTimeZone contextTimezone =
+            _format.shouldAdjustToContextTimeZone(ctxt) ? DateTimeZone.forTimeZone(ctxt.getTimeZone()) : null;
+        DateTimeZone tz = _format.isTimezoneExplicit() ? _format.getTimeZone() : contextTimezone;
         if (tz != null) {
             if (!tz.equals(result.getStart().getZone())) {
                 result = new Interval(result.getStartMillis(), result.getEndMillis(), tz);

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.joda.deser;
 import java.io.IOException;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
@@ -63,5 +64,42 @@ public class IntervalDeserTest extends JodaTestBase
         Interval interval= mapper.readValue("[\"org.joda.time.Interval\",\"1396439982-1396440001\"]", Interval.class);
         assertEquals(1396439982, interval.getStartMillis());
         assertEquals(1396440001, interval.getEndMillis());
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithContextTimeZone() throws IOException
+    {
+        final ObjectMapper mapper = mapperWithModuleBuilder()
+                .defaultTimeZone(TimeZone.getTimeZone("GMT-2:00"))
+                .enable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .build();
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.forOffsetHours(-2));
+        final Interval actualInterval =
+                mapper.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithoutContextTimeZone() throws IOException
+    {
+        final ObjectMapper mapper = mapperWithModuleBuilder()
+                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .build();
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.forOffsetHours(6));
+        final Interval actualInterval =
+                mapper.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
+    }
+
+    public void testIntervalDeserFromIso8601WithTimezoneWithDefaultTimeZone() throws IOException
+    {
+        final ObjectMapper mapper = mapperWithModuleBuilder()
+                .enable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .build();
+        final Interval expectedInterval = new Interval(1000, 2000, DateTimeZone.UTC);
+        final Interval actualInterval =
+                mapper.readValue(quote("1970-01-01T06:00:01.000+06:00/1970-01-01T06:00:02.000+06:00"), Interval.class);
+
+        assertEquals(expectedInterval, actualInterval);
     }
 }


### PR DESCRIPTION
Change `IntervalDeserializer` to use `Interval.parseWithOffset` and
override timezone only if `shouldAdjustToContextTimeZone` is set or
explicit timezone is specified in the format
Add unit tests for `IntervalDeserializer` to cover the 3 scenarios:
- Timezone explicitly provided in deserialization format
- Context timezone enabled
- Neither context timezone enabled nor explicit timezone provided
Resolve: https://github.com/FasterXML/jackson-datatype-joda/issues/104