### PR TITLE
fix #108 shapeOverride ignored when setting up a custom Serializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaDateSerializerBase.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/JodaDateSerializerBase.java
@@ -56,9 +56,7 @@ public abstract class JodaDateSerializerBase<T> extends JodaSerializerBase<T>
     {
         JsonFormat.Value ann = findFormatOverrides(prov, property, handledType());
         if (ann != null) {
-            int shapeOverride = 0;
-            JacksonJodaDateFormat format = _format;
-
+            int shapeOverride;
             Boolean useTimestamp;
 
             // Simple case first: serialize as numeric timestamp?
@@ -75,8 +73,9 @@ public abstract class JodaDateSerializerBase<T> extends JodaSerializerBase<T>
                 shapeOverride = FORMAT_ARRAY;
             } else  {
                 useTimestamp = null;
-                shapeOverride = 0;
+                shapeOverride = _shapeOverride;
             }
+            JacksonJodaDateFormat format = _format;
             // must not call if flag defined, to rely on defaults:
             if (useTimestamp != null) {
                 format = format.withUseTimestamp(useTimestamp);

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JodaSerializationTest.java
@@ -1,16 +1,17 @@
 package com.fasterxml.jackson.datatype.joda.ser;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import org.joda.time.*;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.joda.JodaTestBase;
+import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
+import org.joda.time.*;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
 
 public class JodaSerializationTest extends JodaTestBase
 {
@@ -85,7 +86,7 @@ public class JodaSerializationTest extends JodaTestBase
     /* Tests for LocalTime type
     /**********************************************************
      */
-    
+
     public void testLocalTimeSer() throws IOException
     {
         LocalTime date = new LocalTime(13,20,54);
@@ -98,8 +99,28 @@ public class JodaSerializationTest extends JodaTestBase
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .build();
         assertEquals(quote("13:20:54.000"), mapper.writeValueAsString(date));
+
     }
-    
+
+    public void testLocalTimeSerWithFormatOverride() throws IOException
+    {
+        LocalTime date = new LocalTime(13,20,54);
+
+        // configure a custom serialzer fot the LocalTime
+        SimpleModule testModule = new SimpleModule("TestModule");
+        testModule.addSerializer(LocalTime.class, new LocalTimeSerializer(
+                new JacksonJodaDateFormat(ISODateTimeFormat.hourMinute()), 1));
+
+        ObjectMapper mapper = mapperWithModuleBuilder()
+                .addModule(testModule)
+                .build();
+
+        assertEquals(quote("13:20"), mapper.writeValueAsString(date));
+
+        assertEquals(aposToQuotes("{'contents':'13:20'}"), mapper.writeValueAsString(new Container<>(date)));
+
+    }
+
     public void testLocalTimeSerWithTypeInfo() throws IOException
     {
         LocalTime date = new LocalTime(13,20,54);
@@ -114,6 +135,7 @@ public class JodaSerializationTest extends JodaTestBase
                 .build();
         assertEquals("[\"org.joda.time.LocalTime\",\"13:20:54.000\"]",
                 mapper.writeValueAsString(date));
+
     }
 
     /*


### PR DESCRIPTION
Hi, 
this is a fix for #108 

During the building of the contextual Serializer, use the current shapeOverride instead of resetting it to 0 (default). This way we keep the defined serializer/shape instead of reverting back to the default shape (array).