### PR TITLE
Gracefully handle Deserialization of Joda values from JSON Objects

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateMidnightDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
 
@@ -72,6 +73,14 @@ public class DateMidnightDeserializer
                 return null;
             }
             return local.toDateMidnight();
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            long millis = treeNode.path("millis").asLong(Long.MIN_VALUE);
+            String id = treeNode.path("zone").path("ID").asText();
+            if (millis >= 0) {
+                DateTimeZone tz = DateTimeZone.forID(id);
+                return new DateMidnight(millis, tz);
+            }
         default:
         }
         return (DateMidnight) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p,

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserializer.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonTokenId;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
 
@@ -93,6 +94,14 @@ public class DateTimeDeserializer
             // Not sure if it should use timezone or not...
             // 15-Sep-2015, tatu: impl of 'createParser()' SHOULD handle all timezone/locale setup
             return _format.createParser(ctxt).parseDateTime(str);
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            long millis = treeNode.path("millis").asLong(Long.MIN_VALUE);
+            String id = treeNode.path("zone").path("ID").asText();
+            if (millis >= 0) {
+                tz = DateTimeZone.forID(id);
+                return new DateTime(millis, tz);
+            }
         }
         return _handleNotNumberOrString(p, ctxt);
     }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeZoneDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeZoneDeserializer.java
@@ -7,6 +7,7 @@ import org.joda.time.DateTimeZone;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Deserializer for Joda {@link DateTimeZone}.
@@ -23,9 +24,14 @@ public class DateTimeZoneDeserializer extends JodaDeserializerBase<DateTimeZone>
         if (t == JsonToken.VALUE_NUMBER_INT) {
             // for fun let's allow use of offsets...
             return DateTimeZone.forOffsetHours(p.getIntValue());
-        }
-        if (t == JsonToken.VALUE_STRING) {
+        } else if (t == JsonToken.VALUE_STRING) {
             return DateTimeZone.forID(p.getText().trim());
+        } else if (t == JsonToken.START_OBJECT) {
+            JsonNode treeNode = p.readValueAsTree();
+            String id = treeNode.path("ID").asText();
+            if (id != null && !id.isEmpty()) {
+                return DateTimeZone.forID(id);
+            }
         }
         return _handleNotNumberOrString(p, ctxt);
     }

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DurationDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/DurationDeserializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat;
 
@@ -38,6 +39,12 @@ public class DurationDeserializer
             return new Duration(p.getLongValue());
         case JsonTokenId.ID_STRING:
             return _format.parsePeriod(ctxt, p.getText().trim()).toStandardDuration();
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            long millis = treeNode.path("millis").asLong(Long.MIN_VALUE);
+            if (millis >= 0) {
+                return new Duration(millis);
+            }
         default:
         }
         return _handleNotNumberOrString(p, ctxt);

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/InstantDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/InstantDeserializer.java
@@ -45,6 +45,12 @@ public class InstantDeserializer
             // 11-Sep-2018, tatu: `DateTimeDeserializer` allows timezone inclusion in brackets;
             //    should that be checked here too?
             return Instant.parse(str, _format.createParser(ctxt));
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            long millis = treeNode.path("millis").asLong(Long.MIN_VALUE);
+            if (millis >= 0) {
+                return new Instant(millis);
+            }
         default:
         }
         return _handleNotNumberOrString(p, ctxt);

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
 
@@ -60,6 +61,14 @@ public class LocalDateDeserializer
                 throw ctxt.wrongTokenException(p, handledType(), JsonToken.END_ARRAY, "after LocalDate ints");
             }
             return new LocalDate(year, month, day);
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            int localDateYear = treeNode.path("year").asInt(Integer.MIN_VALUE);
+            int localDateMonth = treeNode.path("monthOfYear").asInt(Integer.MIN_VALUE);
+            int localDateDay = treeNode.path("dayOfMonth").asInt(Integer.MIN_VALUE);
+            if (localDateYear != Integer.MIN_VALUE && localDateMonth >= 0 && localDateDay >= 0) {
+                return new LocalDate(localDateYear, localDateMonth, localDateDay);
+            }
         }
         return (LocalDate) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p,
                 "expected String, Number or JSON Array");

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserializer.java
@@ -8,6 +8,7 @@ import org.joda.time.LocalDateTime;
 import com.fasterxml.jackson.core.*;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
 
@@ -78,6 +79,20 @@ public class LocalDateTimeDeserializer
                 return dt;
             }
             throw ctxt.wrongTokenException(p, handledType(), JsonToken.END_ARRAY, "after LocalDateTime ints");
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            int year = treeNode.path("year").asInt(Integer.MIN_VALUE);
+            int month = treeNode.path("monthOfYear").asInt(Integer.MIN_VALUE);
+            int day = treeNode.path("dayOfMonth").asInt(Integer.MIN_VALUE);
+            int hourOfDay = treeNode.path("hourOfDay").asInt(Integer.MIN_VALUE);
+            int minuteOfHour = treeNode.path("minuteOfHour").asInt(Integer.MIN_VALUE);
+            int secondOfMinute = treeNode.path("secondOfMinute").asInt(Integer.MIN_VALUE);
+            int millisOfSecond = treeNode.path("millisOfSecond").asInt(0); // optional and defaults to zero
+            if (year != Integer.MIN_VALUE && month >= 0 && day >= 0
+                    && hourOfDay >= 0 && minuteOfHour >= 0 && secondOfMinute >= 0) {
+                return new LocalDateTime(year, month, day,
+                        hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond);
+            }
         default:
         }
         return (LocalDateTime) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p,

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig;
 import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
 
@@ -38,6 +39,15 @@ public class LocalTimeDeserializer
             String str = p.getText().trim();
             return (str.length() == 0) ? null
                     : _format.createParser(ctxt).parseLocalTime(str);
+        case JsonTokenId.ID_START_OBJECT:
+            JsonNode treeNode = p.readValueAsTree();
+            int hourOfDay = treeNode.path("hourOfDay").asInt(Integer.MIN_VALUE);
+            int minuteOfHour = treeNode.path("minuteOfHour").asInt(Integer.MIN_VALUE);
+            int secondOfMinute = treeNode.path("secondOfMinute").asInt(Integer.MIN_VALUE);
+            int millisOfSecond = treeNode.path("millisOfSecond").asInt(0); // optional and defaults to zero
+            if (hourOfDay >= 0 && minuteOfHour >= 0 && secondOfMinute >= 0) {
+                return new LocalTime(hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond);
+            }
         default:
         }
         // [HH,MM,ss,ms?]

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserializer.java
@@ -9,6 +9,7 @@ import org.joda.time.MonthDay;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A Jackson deserializer for Joda MonthDay objects.
@@ -39,6 +40,13 @@ public class MonthDayDeserializer extends JodaDateDeserializerBase<MonthDay>
                 return (MonthDay) getNullValue(ctxt);
             }
             return MonthDay.parse(str, _format.createParser(ctxt));
+        } else if (p.hasToken(JsonToken.START_OBJECT)) {
+            JsonNode treeNode = p.readValueAsTree();
+            int month = treeNode.path("monthOfYear").asInt(Integer.MIN_VALUE);
+            int day = treeNode.path("dayOfMonth").asInt(Integer.MIN_VALUE);
+            if (month >= 0 && day >= 0) {
+                return new MonthDay(month, day);
+            }
         }
         return (MonthDay) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p,
                 "expected JSON String");

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/PeriodDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/PeriodDeserializer.java
@@ -75,6 +75,17 @@ public class PeriodDeserializer
         }
         else if (periodName.equals( "Years" )) {
             rp = Years.years( periodValue );
+        }
+        else if (periodName.equals( "Standard" )) {
+            int years = treeNode.path("years").asInt(0);
+            int months = treeNode.path("months").asInt(0);
+            int weeks = treeNode.path("weeks").asInt(0);
+            int days = treeNode.path("days").asInt(0);
+            int hours = treeNode.path("hours").asInt(0);
+            int minutes = treeNode.path("minutes").asInt(0);
+            int seconds = treeNode.path("seconds").asInt(0);
+            int millis = treeNode.path("millis").asInt(0);
+            rp = new Period(years, months, weeks, days, hours, minutes, seconds, millis, PeriodType.standard());
         } else {
             ctxt.reportInputMismatch(handledType(),
                     "Don't know how to deserialize %s using periodName '%s'",

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserializer.java
@@ -9,6 +9,7 @@ import org.joda.time.YearMonth;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A Jackson deserializer for Joda YearMonth objects.
@@ -40,6 +41,13 @@ public class YearMonthDeserializer extends JodaDateDeserializerBase<YearMonth>
                 return null;
             }
             return YearMonth.parse(str, _format.createParser(ctxt));
+        } else if (t == JsonToken.START_OBJECT) {
+            JsonNode treeNode = p.readValueAsTree();
+            int year = treeNode.path("year").asInt(Integer.MIN_VALUE);
+            int month = treeNode.path("monthOfYear").asInt(Integer.MIN_VALUE);
+            if (year != Integer.MIN_VALUE && month != Integer.MIN_VALUE) {
+                return new YearMonth(year, month);
+            }
         }
         return (YearMonth) ctxt.handleUnexpectedToken(getValueType(ctxt), p.currentToken(), p,
                 "expected JSON String");

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/JodaTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/JodaTestBase.java
@@ -56,8 +56,12 @@ public abstract class JodaTestBase extends TestCase
     /**********************************************************************
      */
 
+    protected static MapperBuilder<?,?> mapperBuilder() {
+        return JsonMapper.builder();
+    }
+
     protected static MapperBuilder<?,?> mapperWithModuleBuilder() {
-        return JsonMapper.builder()
+        return mapperBuilder()
                 .addModule(new JodaModule());
     }
 
@@ -69,6 +73,10 @@ public abstract class JodaTestBase extends TestCase
     protected static MapperBuilder<?,?> jodaMapperBuilder(TimeZone tz) {
         return mapperWithModuleBuilder()
                 .defaultTimeZone(tz);
+    }
+
+    protected static ObjectMapper mapper() {
+        return mapperBuilder().build();
     }
 
     protected static ObjectMapper mapperWithModule() {

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/depr/DateMidnightTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/depr/DateMidnightTest.java
@@ -205,4 +205,11 @@ public class DateMidnightTest extends JodaTestBase
         // Is this stable enough for testing?
         assertEquals("America/New_York", resultTz.getID());
     }
+
+    public void testDeserDateMidnightWhichWasSerializedWithoutJodaModule() throws IOException {
+        DateMidnight expectedDateMidnight = new DateMidnight(2020, 1, 1, DateTimeZone.forID("America/New_York"));
+        String json = mapper().writeValueAsString(expectedDateMidnight);
+        DateMidnight dateMidnight = mapperWithModule().readValue(json, DateMidnight.class);
+        assertEquals(expectedDateMidnight, dateMidnight);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeDeserTest.java
@@ -161,4 +161,11 @@ public class DateTimeDeserTest extends JodaTestBase
         DateTimeZone expTZ = DateTimeZone.forID("Asia/Shanghai");
         assertEquals(new DateTime(2017, 1, 1, 1, 1, 1, expTZ), result);
     }
+
+    public void testDeserDateTimeWhichWasSerializedWithoutJodaModule() throws IOException {
+        DateTime expectedDateTime = new DateTime(2020, 1, 1, 3, 22, 51, 229, DateTimeZone.forID("Asia/Shanghai"));
+        String json = mapper().writeValueAsString(expectedDateTime);
+        DateTime dateTime = mapperWithModule().readValue(json, DateTime.class);
+        assertEquals(expectedDateTime, dateTime);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeZoneDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DateTimeZoneDeserTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
+import java.io.IOException;
 import java.util.TimeZone;
 
 import org.joda.time.DateTimeZone;
@@ -44,5 +45,13 @@ public class DateTimeZoneDeserTest extends JodaTestBase
         DateTimeZoneWrapper result2 = MAPPER.readValue(json, DateTimeZoneWrapper.class);    
         assertNotNull(result2.tz);
         assertEquals(input, result2.tz);
+    }
+
+    public void testDeserDateTimeZoneWhichWasSerializedWithoutJodaModule() throws IOException {
+        TimeZone timeZone = TimeZone.getTimeZone("GMT-7");
+        DateTimeZone expectedDateTimeZone = DateTimeZone.forTimeZone(timeZone);
+        String json = mapper().writeValueAsString(expectedDateTimeZone);
+        DateTimeZone dateTimeZone = mapperWithModule().readValue(json, DateTimeZone.class);
+        assertEquals(expectedDateTimeZone, dateTimeZone);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DurationDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/DurationDeserializationTest.java
@@ -103,4 +103,12 @@ public class DurationDeserializationTest extends JodaTestBase
         assertNotNull(map);
         assertTrue(map.containsKey(Duration.standardMinutes(4 * 60 + 30)));
     }
+
+    public void testDeserDurationWhichWasSerializedWithoutJodaModule() throws IOException {
+        long millisInAnHour = 60 * 60 * 1000;
+        Duration expectedDuration = new Duration(millisInAnHour);
+        String json = mapper().writeValueAsString(expectedDuration);
+        Duration duration = mapperWithModule().readValue(json, Duration.class);
+        assertEquals(expectedDuration, duration);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/InstantDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/InstantDeserTest.java
@@ -70,4 +70,15 @@ public class InstantDeserTest extends JodaTestBase
         assertEquals(1972, date.getYear());
         assertEquals(789, date.getMillisOfSecond());
     }
+
+    public void testDeserInstantWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        long timepoint = cal.getTime().getTime();
+        Instant expectedInstant = new Instant(timepoint);
+        String json = mapper().writeValueAsString(expectedInstant);
+        Instant instant = mapperWithModule().readValue(json, Instant.class);
+        assertEquals(expectedInstant, instant);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/IntervalDeserTest.java
@@ -102,4 +102,13 @@ public class IntervalDeserTest extends JodaTestBase
 
         assertEquals(expectedInterval, actualInterval);
     }
+
+    public void testDeserIntervalWhichWasSerializedWithoutJodaModule() throws IOException {
+        long start = 1396439982;
+        long end = 1396440001;
+        Interval expectedInterval = new Interval(start, end, DateTimeZone.forID("America/New_York"));
+        String json = mapper().writeValueAsString(expectedInterval);
+        Interval interval = mapperWithModule().readValue(json, Interval.class);
+        assertEquals(expectedInterval, interval);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateDeserTest.java
@@ -1,8 +1,12 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
 import org.joda.time.LocalDate;
 import org.joda.time.chrono.ISOChronology;
 
@@ -105,5 +109,17 @@ public class LocalDateDeserTest extends JodaTestBase
         assertEquals(2001, date.getYear());
         assertEquals(5, date.getMonthOfYear());
         assertEquals(25, date.getDayOfMonth());
+    }
+
+    public void testDeserLocalDateWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 11, 31, 44);
+        cal.set(Calendar.MILLISECOND, 276);
+        long timepoint = cal.getTime().getTime();
+        Instant instant = new Instant(timepoint);
+        LocalDate expectedLocalDate = new LocalDate(instant, DateTimeZone.UTC);
+        String json = mapper().writeValueAsString(expectedLocalDate);
+        LocalDate localDate = mapperWithModule().readValue(json, LocalDate.class);
+        assertEquals(expectedLocalDate, localDate);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalDateTimeDeserTest.java
@@ -1,8 +1,12 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
 import org.joda.time.LocalDateTime;
 import org.joda.time.chrono.ISOChronology;
 
@@ -121,5 +125,17 @@ public class LocalDateTimeDeserTest extends JodaTestBase
         assertEquals(34, date2.getMinuteOfHour());
         assertEquals(9, date2.getSecondOfMinute());
         assertEquals(1, date2.getMillisOfSecond());
+    }
+
+    public void testDeserLocalDateTimeWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 11, 31, 44);
+        cal.set(Calendar.MILLISECOND, 276);
+        long timepoint = cal.getTime().getTime();
+        Instant instant = new Instant(timepoint);
+        LocalDateTime expectedLocalDateTime = new LocalDateTime(instant, DateTimeZone.UTC);
+        String json = mapper().writeValueAsString(expectedLocalDateTime);
+        LocalDateTime localDateTime = mapperWithModule().readValue(json, LocalDateTime.class);
+        assertEquals(expectedLocalDateTime, localDateTime);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/LocalTimeDeserTest.java
@@ -1,7 +1,12 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
 import org.joda.time.LocalTime;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -65,5 +70,17 @@ public class LocalTimeDeserTest extends JodaTestBase
         assertEquals(45, time2.getMinuteOfHour());
         assertEquals(22, time2.getSecondOfMinute());
         assertEquals(0, time2.getMillisOfSecond());
+    }
+
+    public void testDeserLocalTimeWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 11, 31, 44);
+        cal.set(Calendar.MILLISECOND, 276);
+        long timepoint = cal.getTime().getTime();
+        Instant instant = new Instant(timepoint);
+        LocalTime expectedLocalTime = new LocalTime(instant, DateTimeZone.UTC);
+        String json = mapper().writeValueAsString(expectedLocalTime);
+        LocalTime localTime = mapperWithModule().readValue(json, LocalTime.class);
+        assertEquals(expectedLocalTime, localTime);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/MonthDayDeserTest.java
@@ -1,7 +1,11 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import org.joda.time.Instant;
 import org.joda.time.MonthDay;
 import org.joda.time.chrono.ISOChronology;
 
@@ -75,5 +79,17 @@ public class MonthDayDeserTest extends JodaTestBase
         assertEquals(exp, mapper.writeValueAsString(input));
         final MonthDay result = mapper.readValue(exp, MonthDay.class);
         assertEquals(input, result);
+    }
+
+    public void testDeserMonthDayWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 11, 31, 44);
+        cal.set(Calendar.MILLISECOND, 276);
+        long timepoint = cal.getTime().getTime();
+        Instant instant = new Instant(timepoint);
+        MonthDay expectedMonthDay = new MonthDay(instant);
+        String json = mapper().writeValueAsString(expectedMonthDay);
+        MonthDay monthDay = mapperWithModule().readValue(json, MonthDay.class);
+        assertEquals(expectedMonthDay, monthDay);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/PeriodDeserializationTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/PeriodDeserializationTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -76,5 +77,12 @@ public class PeriodDeserializationTest extends JodaTestBase
         final Map<Period,Long> map = MAPPER.readValue(json, new TypeReference<Map<Period, Long>>() { });
         assertNotNull(map);
         assertTrue(map.containsKey(new Period(1, 2, 3, 4)));
+    }
+
+    public void testDeserPeriodWhichWasSerializedWithoutJodaModule() throws IOException {
+        Period expectedPeriod = new Period(2, 3, 1, 17, 6, 35, 16, 876, PeriodType.standard());
+        String json = mapper().writeValueAsString(expectedPeriod);
+        Period period = mapperWithModule().readValue(json, Period.class);
+        assertEquals(expectedPeriod, period);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/deser/YearMonthDeserTest.java
@@ -1,8 +1,11 @@
 package com.fasterxml.jackson.datatype.joda.deser;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import org.joda.time.Instant;
 import org.joda.time.YearMonth;
 import org.joda.time.chrono.ISOChronology;
 
@@ -61,5 +64,17 @@ public class YearMonthDeserTest extends JodaTestBase
         YearMonth yearMonth = input.value;
         assertEquals(2013, yearMonth.getYear());
         assertEquals(8, yearMonth.getMonthOfYear());
+    }
+
+    public void testDeserYearMonthWhichWasSerializedWithoutJodaModule() throws IOException {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(2020, Calendar.JUNE, 20, 11, 31, 44);
+        cal.set(Calendar.MILLISECOND, 276);
+        long timepoint = cal.getTime().getTime();
+        Instant instant = new Instant(timepoint);
+        YearMonth expectedYearMonth = new YearMonth(instant);
+        String json = mapper().writeValueAsString(expectedYearMonth);
+        YearMonth yearMonth = mapperWithModule().readValue(json, YearMonth.class);
+        assertEquals(expectedYearMonth, yearMonth);
     }
 }


### PR DESCRIPTION
Gracefully handle deserialization of Joda objects that were serialized without first registering the JodaModule. Under such a situation, objects containing Joda types would be serialized with Jackson's default serialization behavior which is to use all the object's public getters to inform serialization. This results in rather verbose output, but no errors or warnings logged.
More critically, the resulting json cannot be deserialized even after registering the JodaModule. Neglecting to register the JodaModule is an easy trap to fall into because doing so was not required in Jackson 1.x, which was a monolith that supported Joda types out of the box. Jackson 2.x was broken out into modules. Anyone serializing objects with Joda types who upgraded to Jackson 2.x without realizing this might have inadvertently serialized and persisted objects which are undeserializable. This fix adds support for deserializing all Joda object types which have been serialized with Jackson's default all-public-getters serializer.