### PR TITLE
Improve schema support for DateTimeZone type

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeZoneSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeZoneSerializer.java
@@ -2,6 +2,9 @@ package com.fasterxml.jackson.datatype.joda.ser;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import org.joda.time.DateTimeZone;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -29,5 +32,11 @@ public class DateTimeZoneSerializer extends JodaSerializerBase<DateTimeZone>
                 typeSer.typeId(value, DateTimeZone.class, JsonToken.VALUE_STRING));
         serialize(value, g, ctxt);
         typeSer.writeTypeSuffix(g, ctxt, typeIdDef);
+    }
+
+    @Override
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
+            throws JsonMappingException {
+        visitor.expectStringFormat(typeHint);
     }
 }


### PR DESCRIPTION
make DateTimeZoneSerializer set the type to "string" to improve schema support (currently the type will be any)