### PR TITLE
Bumped Joda-Time version and updated module-info.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ Joda (https://www.joda.org/joda-time/) data types.
              2.7 for Jackson 2.9
              2.9[.9] for Jackson 2.10+
           -->
-        <version>2.9.9</version>
+        <version>2.10.8</version>
     </dependency>
   </dependencies>
 

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,10 +1,10 @@
 
-// Generated 27-Mar-2019 using Moditect maven plugin
+// Generated 24-Nov-2020 using Moditect maven plugin
 module com.fasterxml.jackson.datatype.joda {
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
-    requires joda.time;
+    requires org.joda.time;
 
     exports com.fasterxml.jackson.datatype.joda;
     exports com.fasterxml.jackson.datatype.joda.cfg;


### PR DESCRIPTION
Improves JPMS compatibility. Changes between 2.9.9 and 2.10.8 (latest) were relatively minor so it should be safe to upgrade to it.