### PR TITLE
Add gradle-module-metadata-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>de.jjohannes</groupId>
+        <artifactId>gradle-module-metadata-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This plugin should add 'module' file to mavenCentral. This file can be used by the Gradle build tool. 