### PR TITLE
Replace the special character with a space

### DIFF
--- a/src/test/java/tools/jackson/datatype/joda/DateTimeTest.java
+++ b/src/test/java/tools/jackson/datatype/joda/DateTimeTest.java
@@ -129,6 +129,12 @@ public class DateTimeTest extends JodaTestBase
         if (json.contains(",")) {
             json = json.replace(", ", " ");
         }
+        // https://bugs.openjdk.org/browse/JDK-8284840
+        // Java 21 uses NBSP/NNBSP prefixed to AM/PM in time format, instead of a normal space
+        if (json.contains("\u202f")) {
+            json = json.replace("\u202f", " ");
+        }
+
         assertEquals(aposToQuotes("{'date':'1/1/70 12:00 AM'}"), json);
     }
 


### PR DESCRIPTION
This MR fixes https://github.com/FasterXML/jackson-datatype-joda/issues/132

Replace special character with a space for the assertion to succeed. 

Testing:
```
$ mvn test
...
INFO] --- maven-surefire-plugin:3.2.1:test (default-test) @ jackson-datatype-joda ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running tools.jackson.datatype.joda.DateTimeTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.359 s -- in tools.jackson.datatype.joda.DateTimeTest
[INFO] Running tools.jackson.datatype.joda.AnnotationTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in tools.jackson.datatype.joda.AnnotationTest
[INFO] Running tools.jackson.datatype.joda.TimeZoneTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in tools.jackson.datatype.joda.TimeZoneTest
[INFO] Running tools.jackson.datatype.joda.deser.DurationDeserializationTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in tools.jackson.datatype.joda.deser.DurationDeserializationTest
[INFO] Running tools.jackson.datatype.joda.deser.LocalDateTimeDeserTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in tools.jackson.datatype.joda.deser.LocalDateTimeDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.PeriodDeserializationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in tools.jackson.datatype.joda.deser.PeriodDeserializationTest
[INFO] Running tools.jackson.datatype.joda.deser.LocalTimeDeserTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in tools.jackson.datatype.joda.deser.LocalTimeDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.MonthDayDeserTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in tools.jackson.datatype.joda.deser.MonthDayDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.DateTimeZoneDeserTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in tools.jackson.datatype.joda.deser.DateTimeZoneDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.YearMonthDeserTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in tools.jackson.datatype.joda.deser.YearMonthDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.LocalDateDeserTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in tools.jackson.datatype.joda.deser.LocalDateDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.ReadablePeriodDeserializerTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in tools.jackson.datatype.joda.deser.ReadablePeriodDeserializerTest
[INFO] Running tools.jackson.datatype.joda.deser.KeyDeserTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in tools.jackson.datatype.joda.deser.KeyDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.InstantDeserTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in tools.jackson.datatype.joda.deser.InstantDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.IntervalDeserTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in tools.jackson.datatype.joda.deser.IntervalDeserTest
[INFO] Running tools.jackson.datatype.joda.deser.DateTimeDeserTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in tools.jackson.datatype.joda.deser.DateTimeDeserTest
[INFO] Running tools.jackson.datatype.joda.JDKSerializabilityTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s -- in tools.jackson.datatype.joda.JDKSerializabilityTest
[INFO] Running tools.jackson.datatype.joda.MixedListTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in tools.jackson.datatype.joda.MixedListTest
[INFO] Running tools.jackson.datatype.joda.TestVersions
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in tools.jackson.datatype.joda.TestVersions
[INFO] Running tools.jackson.datatype.joda.ser.IntervalSerializationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in tools.jackson.datatype.joda.ser.IntervalSerializationTest
[INFO] Running tools.jackson.datatype.joda.ser.JodaSerializationTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in tools.jackson.datatype.joda.ser.JodaSerializationTest
[INFO] Running tools.jackson.datatype.joda.ser.InstantSerializationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in tools.jackson.datatype.joda.ser.InstantSerializationTest
[INFO] Running tools.jackson.datatype.joda.ser.WriteZoneIdTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in tools.jackson.datatype.joda.ser.WriteZoneIdTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 118, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.308 s
[INFO] Finished at: 2024-01-17T15:49:55+13:00
[INFO] ------------------------------------------------------------------------
```