### PR TITLE
Fix #92 `DateTime` serialization result is not same as `java8-moule`'s `ZonedDateTime`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
@@ -162,6 +162,12 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
         if (_locale != null) {
             formatter = formatter.withLocale(_locale);
         }
+
+        // [datatype-joda#98] Since 2.19.1, fix `@JsonFormat.timezone` not taking effect
+        // [If a timezone was explicitly set earlier, retain it on the new formatter
+        if (_explicitTimezone && _jdkTimezone != null) {
+            formatter = formatter.withZone(DateTimeZone.forTimeZone(_jdkTimezone));
+        }
         return new JacksonJodaDateFormat(this, formatter);
     }
 

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
@@ -254,6 +254,28 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
         return formatter;
     }
 
+    /**
+     * Creates a formatter with the specified timezone from the value if any.
+     *
+     * [dataformat-joda#92] DateTime serialization result is not same as Java 8 ZonedDateTime
+     *
+     * @since 2.19.1
+     */
+    public DateTimeFormatter createFormatter(SerializerProvider ctxt, DateTimeZone valueTimeZone)
+    {
+        DateTimeFormatter formatter = createFormatterWithLocale(ctxt);
+        if (!_explicitTimezone) {
+            TimeZone tz = ctxt.getTimeZone();
+            if ((tz != null) && !tz.equals(_jdkTimezone)) {
+                formatter = formatter.withZone(DateTimeZone.forTimeZone(tz));
+            }
+        }
+        if (valueTimeZone != null && !valueTimeZone.equals(_jdkTimezone)) {
+            formatter = formatter.withZone(valueTimeZone);
+        }
+        return formatter;
+    }
+
     public DateTimeFormatter createFormatterWithLocale(SerializerProvider ctxt)
     {
         DateTimeFormatter formatter = _formatter;

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/cfg/JacksonJodaDateFormat.java
@@ -242,16 +242,12 @@ public class JacksonJodaDateFormat extends JacksonJodaFormatBase
         return _formatter;
     }
 
+    /**
+     * @deprecated since 2.19.1 Use {@link #createFormatter(SerializerProvider, DateTimeZone)} instead
+     */
     public DateTimeFormatter createFormatter(SerializerProvider ctxt)
     {
-        DateTimeFormatter formatter = createFormatterWithLocale(ctxt);
-        if (!_explicitTimezone) {
-            TimeZone tz = ctxt.getTimeZone();
-            if ((tz != null) && !tz.equals(_jdkTimezone)) {
-                formatter = formatter.withZone(DateTimeZone.forTimeZone(tz));
-            }
-        }
-        return formatter;
+        return createFormatter(ctxt, null);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeSerializer.java
@@ -52,7 +52,7 @@ public class DateTimeSerializer
             if (numeric) {
                 gen.writeNumber(value.getMillis());
             } else {
-                gen.writeString(_format.createFormatter(provider).print(value));
+                gen.writeString(_format.createFormatter(provider, value.getZone()).print(value));
             }
         } else {
             // and then as per [datatype-joda#44], optional TimeZone inclusion

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeOwnZoneSerialization92Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeOwnZoneSerialization92Test.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.datatype.joda.ser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaTestBase;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces jackson-datatype-joda#92:
+ * DateTime loses its own zone during serialization (normalised to UTC),
+ * so the JSON differs from Java 8 ZonedDateTime output.
+ *
+ * Expected (zone kept):  "2017‑01‑01T01:01:01.000+08:00"
+ * Actual (current bug):  "2016‑12‑31T17:01:01.000Z"
+ */
+public class DateTimeOwnZoneSerialization92Test
+    extends JodaTestBase
+{
+    // Wrapper matches style used in other failing tests
+    static class Wrapper {
+        @JsonFormat(shape = JsonFormat.Shape.STRING,
+                pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ")   // default ISO pattern
+        public DateTime value;
+        Wrapper(DateTime v) { value = v; }
+    }
+
+    private final ObjectMapper MAPPER = mapperWithModuleBuilder()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // string mode
+            .build();
+
+    @Test
+    public void dateTimeShouldRetainItsOwnZone() throws Exception {
+        DateTime europe = new DateTime(
+                2017, 1, 1, 12, 1, 1, 0,
+                DateTimeZone.forID("Europe/Budapest")      // UTC+8
+        );
+
+        String actual = MAPPER.writeValueAsString(new Wrapper(europe));
+
+        // This assertion FAILS today, demonstrating the bug
+        assertEquals("{\"value\":\"2017-01-01T11:01:01.000 Europe/Budapest\"}", actual);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeOwnZoneSerialization92Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/DateTimeOwnZoneSerialization92Test.java
@@ -1,48 +1,40 @@
 package com.fasterxml.jackson.datatype.joda.ser;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaTestBase;
+import java.util.TimeZone;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaTestBase;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Reproduces jackson-datatype-joda#92:
- * DateTime loses its own zone during serialization (normalised to UTC),
- * so the JSON differs from Java 8 ZonedDateTime output.
- *
- * Expected (zone kept):  "2017‑01‑01T01:01:01.000+08:00"
- * Actual (current bug):  "2016‑12‑31T17:01:01.000Z"
- */
+// [dataformat-joda#92] DateTime serialization result is not same as Java 8 ZonedDateTime
 public class DateTimeOwnZoneSerialization92Test
-    extends JodaTestBase
+        extends JodaTestBase
 {
-    // Wrapper matches style used in other failing tests
-    static class Wrapper {
-        @JsonFormat(shape = JsonFormat.Shape.STRING,
-                pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ")   // default ISO pattern
-        public DateTime value;
-        Wrapper(DateTime v) { value = v; }
-    }
-
-    private final ObjectMapper MAPPER = mapperWithModuleBuilder()
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // string mode
-            .build();
+    private final ObjectMapper MAPPER = mapperWithModuleBuilder().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).build();
 
     @Test
     public void dateTimeShouldRetainItsOwnZone() throws Exception {
-        DateTime europe = new DateTime(
-                2017, 1, 1, 12, 1, 1, 0,
-                DateTimeZone.forID("Europe/Budapest")      // UTC+8
-        );
+        DateTime jodaZonedDateTime = new DateTime(2023, 10, 1, 12, 2, 3, 123, DateTimeZone.forID("Asia/Shanghai"));
 
-        String actual = MAPPER.writeValueAsString(new Wrapper(europe));
+        // with WRITE_DATES_WITH_CONTEXT_TIME_ZONE
+        assertEquals("\"2023-10-01T12:02:03.123+08:00\"",
+                MAPPER.writer()
+                .with(TimeZone.getTimeZone("UTC"))
+                .with(SerializationFeature.WRITE_DATES_WITH_CONTEXT_TIME_ZONE)
+                .writeValueAsString(jodaZonedDateTime));
 
-        // This assertion FAILS today, demonstrating the bug
-        assertEquals("{\"value\":\"2017-01-01T11:01:01.000 Europe/Budapest\"}", actual);
+        // without WRITE_DATES_WITH_CONTEXT_TIME_ZONE
+        assertEquals("\"2023-10-01T12:02:03.123+08:00\"",
+                MAPPER.writer()
+                        .with(TimeZone.getTimeZone("UTC"))
+                        .without(SerializationFeature.WRITE_DATES_WITH_CONTEXT_TIME_ZONE)
+                        .writeValueAsString(jodaZonedDateTime));
     }
+
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
@@ -4,6 +4,9 @@ import java.util.TimeZone;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -27,31 +30,49 @@ public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase {
         }
 
     }
-
     private final ObjectMapper MAPPER = mapperWithModuleBuilder()
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .build();
 
     @Test
-    public void patternShouldNotEraseTimeZone()
-            throws Exception {
-        // Explicity set with Timezone
-        _testSerializationOutput(
-                /* expectedHour */ "12",
-                new Wrapper(new DateTime(2018, 1, 1, 12, 1, 2, 3,
-                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))));
-        // Using @JsonFormat
-        _testSerializationOutput(
-                /* expectedHour */ "13",
-                new Wrapper(new DateTime(2018, 1, 1, 12, 1, 2, 3,
-                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))));
+    public void patternShouldNotEraseTimeZone() throws Exception
+    {
+        // DateTime already in Europe/Budapest zone (no shift)
+        _testSerialization(
+                "{\"value\":\"2018-01-01T12:01:02.003 Europe/Budapest\"}",
+                new Wrapper<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest"))))
+        );
+
+        // DateTime in UTC, should shift +1h
+        _testSerialization(
+                "{\"value\":\"2018-01-01T13:01:02.003 Europe/Budapest\"}",
+                new Wrapper<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC"))))
+        );
+
+        // LocalDate
+        _testSerialization(
+                "{\"value\":\"2018-01-01T��:��:��.000 \"}",
+                new Wrapper<>(new LocalDate(2018,1,1))
+        );
+
+        // LocalTime
+        _testSerialization(
+                "{\"value\":\"����-��-��T12:01:02.003 \"}",
+                new Wrapper<>(new LocalTime(12,1,2,3))
+        );
+
+        // LocalDateTime
+        _testSerialization(
+                "{\"value\":\"2018-01-01T12:01:02.003 \"}",
+                new Wrapper<>(new LocalDateTime(2018,1,1,12,1,2,3))
+        );
     }
 
-    private <T> void _testSerializationOutput(String expectedHour, Wrapper<T> wrapper)
-            throws Exception {
+    private void _testSerialization(String expectedJson, Object wrapper) throws Exception {
         String actual = MAPPER.writeValueAsString(wrapper);
-        String exp = "{\"value\":\"2018-01-01T" + expectedHour + ":01:02.003 Europe/Budapest\"}";
-        assertEquals(exp, actual);
+        assertEquals(expectedJson, actual);
     }
 
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
@@ -13,17 +13,19 @@ import com.fasterxml.jackson.datatype.joda.JodaTestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase
-{
-    static class Wrapper {
+public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase {
+    static class Wrapper<T> {
         @JsonFormat(
-                shape   = JsonFormat.Shape.STRING,
+                shape = JsonFormat.Shape.STRING,
                 pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ",
                 timezone = "Europe/Budapest"   // +01:00 in winter
         )
-        public DateTime value;
+        public T value;
 
-        Wrapper(DateTime v) { value = v; }
+        Wrapper(T v) {
+            value = v;
+        }
+
     }
 
     private final ObjectMapper MAPPER = mapperWithModuleBuilder()
@@ -32,27 +34,23 @@ public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase
 
     @Test
     public void patternShouldNotEraseTimeZone()
-            throws Exception
-    {
+            throws Exception {
         // Explicity set with Timezone
         _testSerializationOutput(
                 /* expectedHour */ "12",
-            new DateTime(2018, 1, 1, 12, 1, 2, 3,
-                    DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))
-        );
+                new Wrapper(new DateTime(2018, 1, 1, 12, 1, 2, 3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))));
         // Using @JsonFormat
         _testSerializationOutput(
-               /* expectedHour */ "13",
-            new DateTime(2018, 1, 1, 12, 1, 2, 3,
-                    DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))
-        );
+                /* expectedHour */ "13",
+                new Wrapper(new DateTime(2018, 1, 1, 12, 1, 2, 3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))));
     }
 
-    private void _testSerializationOutput(String expectedHour, DateTime dateTime)
-            throws Exception
-    {
-        String actual = MAPPER.writeValueAsString(new Wrapper(dateTime));
-        String exp = "{\"value\":\"2018-01-01T"+expectedHour+":01:02.003 Europe/Budapest\"}";
+    private <T> void _testSerializationOutput(String expectedHour, Wrapper<T> wrapper)
+            throws Exception {
+        String actual = MAPPER.writeValueAsString(wrapper);
+        String exp = "{\"value\":\"2018-01-01T" + expectedHour + ":01:02.003 Europe/Budapest\"}";
         assertEquals(exp, actual);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
@@ -2,13 +2,14 @@ package com.fasterxml.jackson.datatype.joda.ser;
 
 import java.util.TimeZone;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaTestBase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -33,23 +34,25 @@ public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase
     public void patternShouldNotEraseTimeZone()
             throws Exception
     {
-        // Explicity set with Timezone Europe/Budapest
+        // Explicity set with Timezone
         _testSerializationOutput(
+                /* expectedHour */ "12",
             new DateTime(2018, 1, 1, 12, 1, 2, 3,
                     DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))
         );
-        // Using JsonFormat
+        // Using @JsonFormat
         _testSerializationOutput(
-            new DateTime(2018, 1, 1, 12, 1, 2, 3)
+               /* expectedHour */ "13",
+            new DateTime(2018, 1, 1, 12, 1, 2, 3,
+                    DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))
         );
     }
 
-    private void _testSerializationOutput(
-            DateTime dateTime
-    ) throws Exception
+    private void _testSerializationOutput(String expectedHour, DateTime dateTime)
+            throws Exception
     {
         String actual = MAPPER.writeValueAsString(new Wrapper(dateTime));
-        String exp = "{\"value\":\"2018-01-01T12:01:02.003 Europe/Budapest\"}";
+        String exp = "{\"value\":\"2018-01-01T"+expectedHour+":01:02.003 Europe/Budapest\"}";
         assertEquals(exp, actual);
     }
 

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
@@ -1,0 +1,56 @@
+package com.fasterxml.jackson.datatype.joda.ser;
+
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaTestBase;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase
+{
+    static class Wrapper {
+        @JsonFormat(
+                shape   = JsonFormat.Shape.STRING,
+                pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ",
+                timezone = "Europe/Budapest"   // +01:00 in winter
+        )
+        public DateTime value;
+
+        Wrapper(DateTime v) { value = v; }
+    }
+
+    private final ObjectMapper MAPPER = mapperWithModuleBuilder()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Test
+    public void patternShouldNotEraseTimeZone()
+            throws Exception
+    {
+        // Explicity set with Timezone Europe/Budapest
+        _testSerializationOutput(
+            new DateTime(2018, 1, 1, 12, 1, 2, 3,
+                    DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))
+        );
+        // Using JsonFormat
+        _testSerializationOutput(
+            new DateTime(2018, 1, 1, 12, 1, 2, 3)
+        );
+    }
+
+    private void _testSerializationOutput(
+            DateTime dateTime
+    ) throws Exception
+    {
+        String actual = MAPPER.writeValueAsString(new Wrapper(dateTime));
+        String exp = "{\"value\":\"2018-01-01T12:01:02.003 Europe/Budapest\"}";
+        assertEquals(exp, actual);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/joda/ser/JsonFormatTimeZoneWithPattern98Test.java
@@ -17,57 +17,98 @@ import com.fasterxml.jackson.datatype.joda.JodaTestBase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JsonFormatTimeZoneWithPattern98Test extends JodaTestBase {
-    static class Wrapper<T> {
+    static class Wrapper3Z<T> {
         @JsonFormat(
                 shape = JsonFormat.Shape.STRING,
                 pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZZ",
                 timezone = "Europe/Budapest"   // +01:00 in winter
         )
         public T value;
-
-        Wrapper(T v) {
-            value = v;
-        }
-
+        Wrapper3Z(T v) { value = v; }
     }
+
+    static class Wrapper2Z<T> {
+        @JsonFormat(
+                shape = JsonFormat.Shape.STRING,
+                pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS ZZ",
+                timezone = "Europe/Budapest"
+        )
+        public T value;
+        Wrapper2Z(T v) { value = v; }
+    }
+
+    static class Wrapper1Z<T> {
+        @JsonFormat(
+                shape = JsonFormat.Shape.STRING,
+                pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS Z",
+                timezone = "Europe/Budapest"   // +01:00 in winter
+        )
+        public T value;
+        Wrapper1Z(T v) { value = v; }
+    }
+
     private final ObjectMapper MAPPER = mapperWithModuleBuilder()
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .build();
 
     @Test
-    public void patternShouldNotEraseTimeZone() throws Exception
+    public void patternShouldNotEraseTimeZone()
+        throws Exception
     {
         // DateTime already in Europe/Budapest zone (no shift)
         _testSerialization(
                 "{\"value\":\"2018-01-01T12:01:02.003 Europe/Budapest\"}",
-                new Wrapper<>(new DateTime(2018,1,1,12,1,2,3,
-                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest"))))
-        );
-
+                new Wrapper3Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))));
         // DateTime in UTC, should shift +1h
         _testSerialization(
                 "{\"value\":\"2018-01-01T13:01:02.003 Europe/Budapest\"}",
-                new Wrapper<>(new DateTime(2018,1,1,12,1,2,3,
-                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC"))))
-        );
-
+                new Wrapper3Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))));
         // LocalDate
         _testSerialization(
                 "{\"value\":\"2018-01-01T��:��:��.000 \"}",
-                new Wrapper<>(new LocalDate(2018,1,1))
-        );
-
+                new Wrapper3Z<>(new LocalDate(2018,1,1)));
         // LocalTime
         _testSerialization(
                 "{\"value\":\"����-��-��T12:01:02.003 \"}",
-                new Wrapper<>(new LocalTime(12,1,2,3))
-        );
-
+                new Wrapper3Z<>(new LocalTime(12,1,2,3)));
         // LocalDateTime
         _testSerialization(
                 "{\"value\":\"2018-01-01T12:01:02.003 \"}",
-                new Wrapper<>(new LocalDateTime(2018,1,1,12,1,2,3))
-        );
+                new Wrapper3Z<>(new LocalDateTime(2018,1,1,12,1,2,3)));
+    }
+
+    @Test
+    public void patternShouldNotEraseTimeZoneWithZZ()
+            throws Exception
+    {
+        // DateTime already in Europe/Budapest zone (no shift)
+        _testSerialization(
+                "{\"value\":\"2018-01-01T12:01:02.003 +01:00\"}",
+                new Wrapper2Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))));
+        // DateTime in UTC, should shift +1h
+        _testSerialization(
+                "{\"value\":\"2018-01-01T13:01:02.003 +01:00\"}",
+                new Wrapper2Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))));
+    }
+
+    @Test
+    public void patternShouldNotEraseTimeZoneWithZ()
+        throws Exception
+    {
+        // DateTime already in Europe/Budapest zone (no shift)
+        _testSerialization(
+                "{\"value\":\"2018-01-01T12:01:02.003 +0100\"}",
+                new Wrapper1Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Budapest")))));
+        // DateTime in UTC, should shift +1h
+        _testSerialization(
+                "{\"value\":\"2018-01-01T13:01:02.003 +0100\"}",
+                new Wrapper1Z<>(new DateTime(2018,1,1,12,1,2,3,
+                        DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")))));
     }
 
     private void _testSerialization(String expectedJson, Object wrapper) throws Exception {


### PR DESCRIPTION
I filed https://github.com/FasterXML/jackson-modules-java8/pull/369 test reproduction

Blocked by #167