### PR TITLE
Fix(#175) : Restore `JodaModule` SPI metadata

### DIFF
--- a/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,0 +1,1 @@
+tools.jackson.datatype.joda.JodaModule


### PR DESCRIPTION
As requested in https://github.com/FasterXML/jackson-datatype-joda/issues/175, this restores the `JodaModule` SPI metadata that was removed in 3.0.0-rc6.